### PR TITLE
algorand driver: handle unathorized exception

### DIFF
--- a/packages/algob/src/builtin-tasks/node-info.ts
+++ b/packages/algob/src/builtin-tasks/node-info.ts
@@ -1,5 +1,6 @@
 import { task } from "../internal/core/config/config-env";
 import { createClient } from "../lib/driver";
+import { checkAlgorandUnauthorized } from "../lib/exceptions";
 import { AlgobRuntimeEnv, TaskArguments } from "../types";
 import { TASK_NODE_INFO } from "./task-names";
 
@@ -11,8 +12,12 @@ export default function (): void {
 async function nodeInfo (_taskArgs: TaskArguments, env: AlgobRuntimeEnv): Promise<void> {
   const n = env.network;
   const algocl = createClient(n);
-  const st = await algocl.status().do();
-  console.log("NETWORK NAME", n.name);
-  console.log("NODE ADDRESS", n.config);
-  console.log("NODE STATUS", st);
+  try {
+    const st = await algocl.status().do();
+    console.log("NETWORK NAME", n.name);
+    console.log("NODE ADDRESS", n.config);
+    console.log("NODE STATUS", st);
+  } catch (e) {
+    if (!checkAlgorandUnauthorized(e, n)) { throw e; }
+  }
 }

--- a/packages/algob/src/builtin-tasks/node-info.ts
+++ b/packages/algob/src/builtin-tasks/node-info.ts
@@ -1,6 +1,5 @@
 import { task } from "../internal/core/config/config-env";
 import { createClient } from "../lib/driver";
-import { checkAlgorandUnauthorized } from "../lib/exceptions";
 import { AlgobRuntimeEnv, TaskArguments } from "../types";
 import { TASK_NODE_INFO } from "./task-names";
 
@@ -12,12 +11,8 @@ export default function (): void {
 async function nodeInfo (_taskArgs: TaskArguments, env: AlgobRuntimeEnv): Promise<void> {
   const n = env.network;
   const algocl = createClient(n);
-  try {
-    const st = await algocl.status().do();
-    console.log("NETWORK NAME", n.name);
-    console.log("NODE ADDRESS", n.config);
-    console.log("NODE STATUS", st);
-  } catch (e) {
-    if (!checkAlgorandUnauthorized(e, n)) { throw e; }
-  }
+  const st = await algocl.status().do();
+  console.log("NETWORK NAME", n.name);
+  console.log("NODE ADDRESS", n.config);
+  console.log("NODE STATUS", st);
 }

--- a/packages/algob/src/builtin-tasks/run.ts
+++ b/packages/algob/src/builtin-tasks/run.ts
@@ -94,7 +94,7 @@ export async function runMultipleScripts (
   try {
     return await _runMultipleScripts(runtimeEnv, scriptNames, onSuccessFn, force, logTag, allowWrite);
   } catch (e) {
-    if (!checkAlgorandUnauthorized(e, runtimeEnv.network)) { throw e; } else { throw new Error("Algorand Node: Unauthorized"); }
+    if (!checkAlgorandUnauthorized(e, runtimeEnv.network)) { throw e; }
   }
 }
 

--- a/packages/algob/src/builtin-tasks/run.ts
+++ b/packages/algob/src/builtin-tasks/run.ts
@@ -91,20 +91,6 @@ export async function runMultipleScripts (
   force: boolean,
   logTag: string,
   allowWrite: boolean): Promise<void> {
-  try {
-    return await _runMultipleScripts(runtimeEnv, scriptNames, onSuccessFn, force, logTag, allowWrite);
-  } catch (e) {
-    if (!checkAlgorandUnauthorized(e, runtimeEnv.network)) { throw e; }
-  }
-}
-
-async function _runMultipleScripts (
-  runtimeEnv: AlgobRuntimeEnv,
-  scriptNames: string[],
-  onSuccessFn: (cpData: CheckpointRepo, relativeScriptPath: string) => void,
-  force: boolean,
-  logTag: string,
-  allowWrite: boolean): Promise<void> {
   const log = debug(logTag);
   const cpData: CheckpointRepo = loadCheckpointsRecursive();
   const deployer: AlgobDeployer = mkDeployer(runtimeEnv, cpData, allowWrite);

--- a/packages/algob/src/internal/cli/cli.ts
+++ b/packages/algob/src/internal/cli/cli.ts
@@ -7,6 +7,7 @@ import debug from "debug";
 import semver from "semver";
 
 import { TASK_HELP, TASK_INIT } from "../../builtin-tasks/task-names";
+import { checkAlgorandUnauthorized } from "../../lib/exceptions";
 import { TaskArguments } from "../../types";
 import { ALGOB_NAME } from "../constants";
 import { BuilderContext } from "../context";
@@ -133,7 +134,11 @@ async function main (): Promise<void> {
 
     // const tBeforeRun = new Date().getTime();
 
-    await env.run(taskName, taskArguments);
+    try {
+      await env.run(taskName, taskArguments);
+    } catch (e) {
+      if (!checkAlgorandUnauthorized(e, env.network)) { throw e; }
+    }
 
     // const tAfterRun = new Date().getTime();
     // if (tAfterRun - tBeforeRun > ANALYTICS_SLOW_TASK_THRESHOLD) {

--- a/packages/algob/src/lib/exceptions.ts
+++ b/packages/algob/src/lib/exceptions.ts
@@ -1,8 +1,12 @@
 import type { Network } from "../types";
 
 export function checkAlgorandUnauthorized (e: any, n: Network): boolean { // eslint-disable-line @typescript-eslint/no-explicit-any
-  if (e instanceof Error && (e.message === 'Unauthorized')) {
+  if (e instanceof Error &&
+    (e.message === 'Unauthorized') &&
+    (e as any).response?.text === '{"message":"Invalid API Token"}\n') {
     console.error("Wrong credentials to access the Algorand Node. Please verify the access token for the", '"' + n.name + '"', "network.");
+    // we finish it here, because we know what's wrong and there is not point
+    // to rethrow the exception
     process.exit(1);
   }
   return false;

--- a/packages/algob/src/lib/exceptions.ts
+++ b/packages/algob/src/lib/exceptions.ts
@@ -3,7 +3,7 @@ import type { Network } from "../types";
 export function checkAlgorandUnauthorized (e: any, n: Network): boolean { // eslint-disable-line @typescript-eslint/no-explicit-any
   if (e instanceof Error && (e.message === 'Unauthorized')) {
     console.error("Wrong credentials to access the Algorand Node. Please verify the access token for the", '"' + n.name + '"', "network.");
-    return true;
+    process.exit(1);
   }
   return false;
 }

--- a/packages/algob/src/lib/exceptions.ts
+++ b/packages/algob/src/lib/exceptions.ts
@@ -1,0 +1,9 @@
+import type { Network } from "../types";
+
+export function checkAlgorandUnauthorized (e: any, n: Network): boolean { // eslint-disable-line @typescript-eslint/no-explicit-any
+  if (e instanceof Error && (e.message === 'Unauthorized')) {
+    console.error("Wrong credentials to access the Algorand Node. Please verify the access token for the", '"' + n.name + '"', "network.");
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
This PR handles a cryptic runtime exception when Algorand client is initialized with wrong credentials

```
% yarn algob:test node-info
yarn run v1.22.4
$ mkdir -p project-test && cd project-test && node ../build/internal/cli/cli.js node-info
An unexpected error occurred: Unauthorized

Error: Unauthorized
    at Request.callback (/home/robert/projects/algorand/algorand-builder/node_modules/superagent/lib/node/index.js:804:15)
    at /home/robert/projects/algorand/algorand-builder/node_modules/superagent/lib/node/index.js:1036:18
    at IncomingMessage.<anonymous> (/home/robert/projects/algorand/algorand-builder/node_modules/superagent/lib/node/parsers/json.js:19:7)
    at IncomingMessage.emit (events.js:326:22)
    at endReadableNT (_stream_readable.js:1244:12)
    at processTicksAndRejections (internal/process/task_queues.js:80:21)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
[1]    35648 exit 1     yarn algob:test node-info
```


After this PR, the we will see more "useful" error message:

```
% yarn algob:test node-info              
yarn run v1.22.4
$ mkdir -p project-test && cd project-test && node ../build/internal/cli/cli.js node-info
Wrong credentials to access the Algorand Node. Please verify the access token for the "default" network.
error Command failed with exit code 1.
```