### PR TITLE
Add support for external paramters to PyTEAL scritps

### DIFF
--- a/examples/algobpy/parse-args.py
+++ b/examples/algobpy/parse-args.py
@@ -1,0 +1,17 @@
+import sys
+import yaml
+
+'''
+Overwrites scParam values if args is defined and has keys common from scParam
+'''
+def parseArgs(args, scParam):
+    
+    # decode external parameter and update current values.
+    # (if an external paramter is passed)
+    try:
+      param = yaml.safe_load(args)
+      for key, value in param.items():
+        scParam[key] = value
+      return scParam
+    except yaml.YAMLError as exc:
+      print(exc)

--- a/examples/asa/scripts/2-gold-asc.js
+++ b/examples/asa/scripts/2-gold-asc.js
@@ -8,14 +8,14 @@ async function run(runtimeEnv, deployer) {
 
   await executeTransaction(deployer, mkParam(masterAccount, goldOwnerAccount.addr, 200000000, {note: "funding account"}));
 
-  await deployer.fundLsig("2-gold-contract-asc.teal", [],
-    { funder: goldOwnerAccount, fundingMicroAlgo: 101000 }, {});   // sending 0.101 Algo
+  await deployer.fundLsig("2-gold-contract-asc.teal",
+    { funder: goldOwnerAccount, fundingMicroAlgo: 101000 }, {}, []);   // sending 0.101 Algo
 
-  const ascInfoAlgoDelegated = await deployer.mkDelegatedLsig("3-gold-delegated-asc.teal", [],
-  goldOwnerAccount);
+  const ascInfoAlgoDelegated = await deployer.mkDelegatedLsig("3-gold-delegated-asc.teal",
+  goldOwnerAccount, []);
 
-  const ascInfoGoldDelegated = await deployer.mkDelegatedLsig("4-gold-asa.teal", [],
-   goldOwnerAccount); 
+  const ascInfoGoldDelegated = await deployer.mkDelegatedLsig("4-gold-asa.teal",
+   goldOwnerAccount, []); 
 
   console.log(ascInfoAlgoDelegated);
   console.log(ascInfoGoldDelegated);

--- a/examples/asa/scripts/transfer/gold-contract-sc.js
+++ b/examples/asa/scripts/transfer/gold-contract-sc.js
@@ -12,7 +12,7 @@ async function run(runtimeEnv, deployer) {
 
   // Transactions for Transaction for ALGO - Contract : '2-gold-contract-asc.teal'  (Contract Mode)
   // sender is contract account
-  const lsig = await deployer.loadLogic("2-gold-contract-asc.teal");
+  const lsig = await deployer.loadLogic("2-gold-contract-asc.teal", []);
   const sender = lsig.address();
   
   let txnParam = {

--- a/examples/htlc-pyteal/scripts/fund-pyteal.js
+++ b/examples/htlc-pyteal/scripts/fund-pyteal.js
@@ -21,8 +21,8 @@ async function run(runtimeEnv, deployer) {
   // secret value hashed with sha256 will produce our image hash : QzYhq9JlYbn2QdOMrhyxVlNtNjeyvyJc/I8d8VAGfGc=
   const secret = "hero wisdom green split loop element vote belt";
   
-  await deployer.fundLsig("htlc.py", [ secret ],
-    { funder: bobAccount, fundingMicroAlgo: 202000000 }, {}); 
+  await deployer.fundLsig("htlc.py",
+    { funder: bobAccount, fundingMicroAlgo: 202000000 }, {}, [ secret ]); 
   
 }
 

--- a/examples/ref-templates/assets/dynamic-fee.py
+++ b/examples/ref-templates/assets/dynamic-fee.py
@@ -98,8 +98,8 @@ if __name__ == "__main__":
     "TMPL_LEASE": "023sdDE2"
   }
 
-  # decode external parameters and update current values.
-  # (if external paramters are passed)
+  # decode external parameter and update current values.
+  # (if an external paramter is passed)
   if(sys.argv[1] != "\n"):
     try:
       param = yaml.safe_load(sys.argv[1])

--- a/examples/ref-templates/assets/dynamic-fee.py
+++ b/examples/ref-templates/assets/dynamic-fee.py
@@ -1,12 +1,7 @@
-from pyteal import *
+import sys
+import yaml
 
-#replace the following params with your custom values
-john = Addr("2UBZKFR6RCZL7R24ZG327VKPTPJUPFM6WTG7PJG2ZJLU234F5RGXFLTAKA")
-master = Addr("WWYNX3TKQYVEREVSW6QQP3SXSFOCE3SKUSEIVJ7YAGUPEACNI5UGI4DZCE")
-amount = 700000
-first_valid = 10
-last_valid = 1000000
-lease = Bytes("base64", "023sdDE2")
+from pyteal import *
 
 def dynamic_fee(TMPL_TO,
                 TMPL_AMT,
@@ -92,4 +87,31 @@ def dynamic_fee(TMPL_TO,
     return And(required_condition, params_condition)
     
 if __name__ == "__main__":
-    print(compileTeal(dynamic_fee(john, amount, master, first_valid, last_valid, lease), Mode.Signature))
+
+#replace these values with your customized values or pass an external parameter
+  scParam = {
+    "TMPL_TO": "2UBZKFR6RCZL7R24ZG327VKPTPJUPFM6WTG7PJG2ZJLU234F5RGXFLTAKA",
+    "TMPL_AMT": 700000,
+    "TMPL_CLS": "WWYNX3TKQYVEREVSW6QQP3SXSFOCE3SKUSEIVJ7YAGUPEACNI5UGI4DZCE",
+    "TMPL_FV": 10,
+    "TMPL_LV": 1000000,
+    "TMPL_LEASE": "023sdDE2"
+  }
+
+  # decode external parameters and update current values.
+  # (if external paramters are passed)
+  if(sys.argv[1] != "\n"):
+    try:
+      param = yaml.safe_load(sys.argv[1])
+      for key, value in param.items():
+        scParam[key] = value
+    except yaml.YAMLError as exc:
+      print(exc)
+
+  print(compileTeal(dynamic_fee(
+    Addr(scParam["TMPL_TO"]), 
+    scParam["TMPL_AMT"], 
+    Addr(scParam["TMPL_CLS"]), 
+    scParam["TMPL_FV"], 
+    scParam["TMPL_LV"], 
+    Bytes("base64", scParam["TMPL_LEASE"])), Mode.Signature))

--- a/examples/ref-templates/assets/dynamic-fee.py
+++ b/examples/ref-templates/assets/dynamic-fee.py
@@ -1,5 +1,7 @@
 import sys
-import yaml
+# Add parent-parent directory to path so that algobpy can be imported
+sys.path.insert(0,'../..')
+from algobpy.parse import parseArgs
 
 from pyteal import *
 
@@ -98,15 +100,9 @@ if __name__ == "__main__":
     "TMPL_LEASE": "023sdDE2"
   }
 
-  # decode external parameter and update current values.
-  # (if an external paramter is passed)
-  if(sys.argv[1] != "\n"):
-    try:
-      param = yaml.safe_load(sys.argv[1])
-      for key, value in param.items():
-        scParam[key] = value
-    except yaml.YAMLError as exc:
-      print(exc)
+  # Overwrite scParam if sys.argv[1] is passed
+  if(len(sys.argv) > 1):
+    scParam = parseArgs(sys.argv[1], scParam)
 
   print(compileTeal(dynamic_fee(
     Addr(scParam["TMPL_TO"]), 
@@ -115,3 +111,4 @@ if __name__ == "__main__":
     scParam["TMPL_FV"], 
     scParam["TMPL_LV"], 
     Bytes("base64", scParam["TMPL_LEASE"])), Mode.Signature))
+    

--- a/examples/ref-templates/scripts/dynamic-fee.js
+++ b/examples/ref-templates/scripts/dynamic-fee.js
@@ -6,24 +6,25 @@ async function run(runtimeEnv, deployer) {
   const johnAccount = deployer.accountsByName.get("john-account");
   const bobAccount = deployer.accountsByName.get("bob-account");
 
-  // setup a contract account and send 1 ALGO from master
-  await deployer.fundLsig("dynamic-fee.py", [], { funder: masterAccount, fundingMicroAlgo: 100000000 }, { closeRemainderTo: masterAccount.addr }); 
-
-  let contract = await deployer.loadLogic("dynamic-fee.py");
-  const escrow = contract.address(); //contract account
-  
   scInitParam = {
     TMPL_TO: johnAccount.addr,  
-    TMPL_AMT: 7109,
+    TMPL_AMT: 700000,
     TMPL_CLS: masterAccount.addr,
     TMPL_FV: 10,
     TMPL_LV: 1000000,
     TMPL_LEASE: "023sdDE2"
   };
+  // setup a contract account and send 1 ALGO from master
+  await deployer.fundLsig("dynamic-fee.py", 
+  { funder: masterAccount, fundingMicroAlgo: 100000000 }, { closeRemainderTo: masterAccount.addr }, [], scInitParam); 
 
-  await deployer.mkDelegatedLsig("dynamic-fee.py", [], masterAccount, scInitParam); // sign contract
+  let contract = await deployer.loadLogic("dynamic-fee.py", [], scInitParam);
+  const escrow = contract.address(); //contract account
+
+  await deployer.mkDelegatedLsig("dynamic-fee.py", masterAccount, [], scInitParam); // sign contract
   const signedContract =  await deployer.getDelegatedLsig('dynamic-fee.py');
-  
+  console.log("SIGn1 ", signedContract);
+
   let transactions = [
     mkTxnParams(masterAccount, escrow, 1000, signedContract, {}),
     mkTxnParams({ addr: escrow}, johnAccount.addr, 700000, contract, { totalFee: 1000, closeRemainderTo: bobAccount.addr })]

--- a/examples/ref-templates/scripts/dynamic-fee.js
+++ b/examples/ref-templates/scripts/dynamic-fee.js
@@ -12,7 +12,16 @@ async function run(runtimeEnv, deployer) {
   let contract = await deployer.loadLogic("dynamic-fee.py");
   const escrow = contract.address(); //contract account
   
-  await deployer.mkDelegatedLsig("dynamic-fee.py", [], masterAccount); // sign contract
+  scInitParam = {
+    TMPL_TO: johnAccount.addr,  
+    TMPL_AMT: 7109,
+    TMPL_CLS: "WWYNX3TKQYVEREVSW6QQP3SXSFOCE3SKUSEIVJ7YAGUPEACNI5UGI4DZCE",
+    TMPL_FV: 10,
+    TMPL_LV: 1000000,
+    TMPL_LEASE: "023sdDE2"
+  };
+
+  await deployer.mkDelegatedLsig("dynamic-fee.py", [], masterAccount, scInitParam); // sign contract
   const signedContract =  await deployer.getDelegatedLsig('dynamic-fee.py');
   
   let transactions = [

--- a/examples/ref-templates/scripts/dynamic-fee.js
+++ b/examples/ref-templates/scripts/dynamic-fee.js
@@ -15,7 +15,7 @@ async function run(runtimeEnv, deployer) {
   scInitParam = {
     TMPL_TO: johnAccount.addr,  
     TMPL_AMT: 7109,
-    TMPL_CLS: "WWYNX3TKQYVEREVSW6QQP3SXSFOCE3SKUSEIVJ7YAGUPEACNI5UGI4DZCE",
+    TMPL_CLS: masterAccount.addr,
     TMPL_FV: 10,
     TMPL_LV: 1000000,
     TMPL_LEASE: "023sdDE2"

--- a/examples/ref-templates/scripts/htlc.js
+++ b/examples/ref-templates/scripts/htlc.js
@@ -14,7 +14,8 @@ async function run(runtimeEnv, deployer) {
   const wrongSecret = "hero wisdom red split loop element vote belt";
 
   // setup a contract account and send 1 ALGO from master
-  await deployer.fundLsig("htlc.py", [], { funder: masterAccount, fundingMicroAlgo: 1000000 }, { closeRemainderTo: johnAccount.addr }); 
+  await deployer.fundLsig("htlc.py", { funder: masterAccount, fundingMicroAlgo: 1000000 }, 
+  	{ closeRemainderTo: johnAccount.addr }, []); 
 
   let contract = await deployer.loadLogic("htlc.py", [ wrongSecret ]);
   let contractAddress = contract.address();

--- a/packages/algob/src/internal/deployer.ts
+++ b/packages/algob/src/internal/deployer.ts
@@ -102,8 +102,8 @@ class DeployerBasicMode {
    * @param scParams parameters
    * @returns {LogicSig} loaded logic signature from assets/<file_name>.teal
    */
-  async loadLogic (name: string, scParams: LogicSigArgs): Promise<LogicSig> {
-    return await getLsig(name, scParams, this.algoOp.algodClient);
+  async loadLogic (name: string, scParams: LogicSigArgs, scInitParam?: Object): Promise<LogicSig> {
+    return await getLsig(name, scParams, this.algoOp.algodClient, scInitParam);
   }
 
   /**
@@ -226,9 +226,9 @@ export class DeployerDeployMode extends DeployerBasicMode implements AlgobDeploy
    * @param payFlags - as per SPEC
    */
   async fundLsig (name: string, scParams: LogicSigArgs, flags: FundASCFlags,
-    payFlags: TxParams): Promise<void> {
+    payFlags: TxParams, scInitParam?: Object): Promise<void> {
     try {
-      await this.algoOp.fundLsig(name, scParams, flags, payFlags, this.txWriter);
+      await this.algoOp.fundLsig(name, scParams, flags, payFlags, this.txWriter, scInitParam);
     } catch (error) {
       console.log(error);
       throw error;
@@ -242,11 +242,12 @@ export class DeployerDeployMode extends DeployerBasicMode implements AlgobDeploy
    * @param scParams - SC parameters
    * @param signer   - signer
    */
-  async mkDelegatedLsig (name: string, scParams: LogicSigArgs, signer: Account): Promise<LsigInfo> {
+  async mkDelegatedLsig (
+    name: string, scParams: LogicSigArgs, signer: Account, scInitParam?: Object): Promise<LsigInfo> {
     this.assertNoAsset(name);
     let lsigInfo = {} as any;
     try {
-      const lsig = await getLsig(name, scParams, this.algoOp.algodClient);
+      const lsig = await getLsig(name, scParams, this.algoOp.algodClient, scInitParam);
       lsig.sign(signer.sk);
       lsigInfo = {
         creator: signer.addr,
@@ -274,13 +275,14 @@ export class DeployerDeployMode extends DeployerBasicMode implements AlgobDeploy
     approvalProgram: string,
     clearProgram: string,
     flags: SSCDeploymentFlags,
-    payFlags: TxParams): Promise<SSCInfo> {
+    payFlags: TxParams,
+    scInitParam?: Object): Promise<SSCInfo> {
     const name = approvalProgram + "-" + clearProgram;
     this.assertNoAsset(name);
     let sscInfo = {} as any;
     try {
       sscInfo = await this.algoOp.deploySSC(
-        approvalProgram, clearProgram, flags, payFlags, this.txWriter);
+        approvalProgram, clearProgram, flags, payFlags, this.txWriter, scInitParam);
     } catch (error) {
       persistCheckpoint(this.txWriter.scriptName, this.cpData.strippedCP);
 

--- a/packages/algob/src/internal/deployer.ts
+++ b/packages/algob/src/internal/deployer.ts
@@ -1,6 +1,5 @@
 import type { LogicSig, LogicSigArgs, MultiSig } from "algosdk";
 import * as algosdk from "algosdk";
-import { unknown } from "zod";
 
 import { txWriter } from "../internal/tx-log-writer";
 import { AlgoOperator } from "../lib/algo-operator";

--- a/packages/algob/src/lib/algo-operator.ts
+++ b/packages/algob/src/lib/algo-operator.ts
@@ -38,15 +38,15 @@ export interface AlgoOperator {
   deployASA: (
     name: string, asaDef: ASADef, flags: ASADeploymentFlags, accounts: Accounts, txWriter: txWriter
   ) => Promise<ASAInfo>
-  fundLsig: (name: string, scParams: LogicSigArgs, flags: FundASCFlags, payFlags: TxParams,
-    txWriter: txWriter, scInitParam?: Object) => Promise<LsigInfo>
+  fundLsig: (name: string, flags: FundASCFlags, payFlags: TxParams,
+    txWriter: txWriter, scParams: LogicSigArgs, scInitParam?: unknown) => Promise<LsigInfo>
   deploySSC: (
     approvalProgram: string,
     clearProgram: string,
     flags: SSCDeploymentFlags,
     payFlags: TxParams,
     txWriter: txWriter,
-    scInitParam?: Object) => Promise<SSCInfo>
+    scInitParam?: unknown) => Promise<SSCInfo>
   waitForConfirmation: (txId: string) => Promise<algosdk.ConfirmedTxInfo>
   optInToASA: (
     asaName: string, assetIndex: number, account: Account, params: TxParams
@@ -56,7 +56,7 @@ export interface AlgoOperator {
   ) => Promise<void>
   optInToSSC: (
     sender: Account, appId: number, payFlags: TxParams, appArgs?: Uint8Array[]) => Promise<void>
-  ensureCompiled: (name: string, force: boolean, scInitParam?: Object) => Promise<ASCCache>
+  ensureCompiled: (name: string, force?: boolean, scInitParam?: unknown) => Promise<ASCCache>
 }
 
 export class AlgoOperatorImpl implements AlgoOperator {
@@ -201,19 +201,20 @@ export class AlgoOperatorImpl implements AlgoOperator {
   /**
    * Description - This function will send Algos to ASC account in "Contract Mode"
    * @param name     - ASC filename
-   * @param scParams - SC parameters
    * @param flags    - FundASC flags (as per SPEC)
    * @param payFlags - as per SPEC
    * @param txWriter - transaction log writer
+   * @param scParams: Smart contract Parameters(Used while calling smart contract)
+   * @param scInitParam : Smart contract initialization parameters.
    */
   async fundLsig (
     name: string,
-    scParams: LogicSigArgs,
     flags: FundASCFlags,
     payFlags: TxParams,
     txWriter: txWriter,
-    scInitParam?: Object): Promise<LsigInfo> {
-    const lsig = await getLsig(name, scParams, this.algodClient, scInitParam);
+    scParams: LogicSigArgs,
+    scInitParam?: unknown): Promise<LsigInfo> {
+    const lsig = await getLsig(name, this.algodClient, scParams, scInitParam);
     const contractAddress = lsig.address();
 
     const params = await tx.mkSuggestedParams(this.algodClient, payFlags);
@@ -246,6 +247,7 @@ export class AlgoOperatorImpl implements AlgoOperator {
    * @param flags         SSCDeploymentFlags
    * @param payFlags      TxParams
    * @param txWriter
+   * @param scInitParam : Smart contract initialization parameters.
    */
   async deploySSC (
     approvalProgram: string,
@@ -253,7 +255,7 @@ export class AlgoOperatorImpl implements AlgoOperator {
     flags: SSCDeploymentFlags,
     payFlags: TxParams,
     txWriter: txWriter,
-    scInitParam?: Object): Promise<SSCInfo> {
+    scInitParam?: unknown): Promise<SSCInfo> {
     const sender = flags.sender.addr;
     const params = await tx.mkSuggestedParams(this.algodClient, payFlags);
 
@@ -322,7 +324,7 @@ export class AlgoOperatorImpl implements AlgoOperator {
     await this.waitForConfirmation(txId);
   }
 
-  async ensureCompiled (name: string, force: boolean, scInitParam?: Object): Promise<ASCCache> {
+  async ensureCompiled (name: string, force?: boolean, scInitParam?: unknown): Promise<ASCCache> {
     return await this.compileOp.ensureCompiled(name, force, scInitParam);
   }
 }

--- a/packages/algob/src/lib/compile.ts
+++ b/packages/algob/src/lib/compile.ts
@@ -31,7 +31,8 @@ export class CompileOp {
   //   (Examples: `mysc.teal, security/rbac.teal`)
   //   MUST have a .teal, .lsig or .py extension
   // @param force: if true it will force recompilation even if the cache is up to date.
-  async ensureCompiled (filename: string, force?: boolean, scInitParam?: Object): Promise<ASCCache> {
+  // @param scInitParam : Smart contract initialization parameters.
+  async ensureCompiled (filename: string, force?: boolean, scInitParam?: unknown): Promise<ASCCache> {
     if (force === undefined) {
       force = false;
     }
@@ -123,7 +124,7 @@ export class PyCompileOp {
    * @param force    : if true it will force recompilation even if the cache is up to date.
    * @param scInitParam : Smart Contract Initialization Parameters
    */
-  async ensureCompiled (filename: string, force?: boolean, scInitParam?: Object): Promise<PyASCCache> {
+  async ensureCompiled (filename: string, force?: boolean, scInitParam?: unknown): Promise<PyASCCache> {
     if (!filename.endsWith(pyExt)) {
       throw new Error(`filename "${filename}" must end with "${pyExt}"`);
     }
@@ -171,10 +172,12 @@ export class PyCompileOp {
   /**
    * Description: Runs a subprocess to execute python script
    * @param filename : python filename in assets folder
+   * @param scInitParam : Smart contract initialization parameters.
    */
   private runPythonScript (filename: string, scInitParam?: string): SpawnSyncReturns<string> {
     // used spawnSync instead of spawn, as it is synchronous
     if (scInitParam === undefined) {
+      console.log("--------------OK-------------");
       return spawnSync(
         'python3', [
           path.join(ASSETS_DIR, filename)
@@ -182,6 +185,8 @@ export class PyCompileOp {
       );
     }
 
+    console.log("--------------OK1-------------");
+    console.log(scInitParam);
     return spawnSync('python3', [
       path.join(ASSETS_DIR, filename),
       scInitParam
@@ -192,6 +197,7 @@ export class PyCompileOp {
   /**
    * Description: returns TEAL code using pyTeal compiler
    * @param filename : python filename in assets folder
+   * @param scInitParam : Smart contract initialization parameters.
    */
   compilePyTeal (filename: string, scInitParam?: string): string {
     const subprocess: SpawnSyncReturns<string> = this.runPythonScript(filename, scInitParam);

--- a/packages/algob/src/lib/compile.ts
+++ b/packages/algob/src/lib/compile.ts
@@ -10,7 +10,6 @@ import { ERRORS } from "../internal/core/errors-list";
 import { assertDir, ASSETS_DIR, CACHE_DIR } from "../internal/core/project-structure";
 import { timestampNow } from "../lib/time";
 import type { ASCCache, PyASCCache } from "../types";
-import { AddressSchema } from "../types-input";
 
 export const tealExt = ".teal";
 export const pyExt = ".py";

--- a/packages/algob/src/lib/compile.ts
+++ b/packages/algob/src/lib/compile.ts
@@ -129,7 +129,8 @@ export class PyCompileOp {
       throw new Error(`filename "${filename}" must end with "${pyExt}"`);
     }
 
-    const param = YAML.stringify(scInitParam);
+    let param: string | undefined = YAML.stringify(scInitParam);
+    if (scInitParam === undefined) { param = undefined; }
 
     const content = this.compilePyTeal(filename, param);
     const [teal, thash] = [content, murmurhash.v3(content)];
@@ -177,7 +178,6 @@ export class PyCompileOp {
   private runPythonScript (filename: string, scInitParam?: string): SpawnSyncReturns<string> {
     // used spawnSync instead of spawn, as it is synchronous
     if (scInitParam === undefined) {
-      console.log("--------------OK-------------");
       return spawnSync(
         'python3', [
           path.join(ASSETS_DIR, filename)
@@ -185,8 +185,6 @@ export class PyCompileOp {
       );
     }
 
-    console.log("--------------OK1-------------");
-    console.log(scInitParam);
     return spawnSync('python3', [
       path.join(ASSETS_DIR, filename),
       scInitParam

--- a/packages/algob/src/lib/lsig.ts
+++ b/packages/algob/src/lib/lsig.ts
@@ -11,10 +11,14 @@ import { CompileOp } from "./compile";
  * @param scParams : parameters
  * @param algodClient : algodClient
  */
-export async function getLsig (name: string, scParams: LogicSigArgs, algodClient: algosdk.Algodv2):
-Promise<LogicSig> {
+export async function getLsig (
+  name: string,
+  scParams: LogicSigArgs,
+  algodClient: algosdk.Algodv2,
+  scInitParam?: Object):
+  Promise<LogicSig> {
   const compileOp = new CompileOp(algodClient);
-  const result: ASCCache = await compileOp.ensureCompiled(name, false);
+  const result: ASCCache = await compileOp.ensureCompiled(name, false, scInitParam);
   const program = result.toBytes;
   return algosdk.makeLogicSig(program, scParams);
 }

--- a/packages/algob/src/lib/lsig.ts
+++ b/packages/algob/src/lib/lsig.ts
@@ -13,9 +13,9 @@ import { CompileOp } from "./compile";
  */
 export async function getLsig (
   name: string,
-  scParams: LogicSigArgs,
   algodClient: algosdk.Algodv2,
-  scInitParam?: Object):
+  scParams: LogicSigArgs,
+  scInitParam?: unknown):
   Promise<LogicSig> {
   const compileOp = new CompileOp(algodClient);
   const result: ASCCache = await compileOp.ensureCompiled(name, false, scInitParam);

--- a/packages/algob/src/types.ts
+++ b/packages/algob/src/types.ts
@@ -485,34 +485,72 @@ export interface AlgobDeployer {
   isDeployMode: boolean
   accounts: Account[]
   accountsByName: Accounts
+
+  // Puts metadata in checkpount
   putMetadata: (key: string, value: string) => void
+
+  // gets metadata from the checkpoint
   getMetadata: (key: string) => string | undefined
+
+  /**
+   * Description: Deploys ASA to the network
+   * @param name: name of the ASA
+   * @param flags: ASADeplymentFlags
+   */
   deployASA: (name: string, flags: ASADeploymentFlags) => Promise<ASAInfo>
+
+  /**
+   * Description: funds logic signature account
+   * @param name: Stateless Smart Contract filename (must be present in assets folder)
+   * @param payFlags: Transaction Parameters
+   * @param scParams: Smart contract Parameters(Used while calling smart contract)
+   * @param scInitParam : Smart contract initialization parameters.
+   */
   fundLsig: (
-    name: string, // ASC filename
-    scParams: LogicSigArgs, // Parameters
+    name: string,
     flags: FundASCFlags,
     payFlags: TxParams,
-    scInitParam?: Object
+    scParams: LogicSigArgs,
+    scInitParam?: unknown
   ) => void
+
+  /**
+   * Description: Make delegated logic signature signed by signer
+   * @param name: Stateless Smart Contract filename (must be present in assets folder)
+   * @param signer: Signer Account which will sign the smart contract
+   * @param scParams: Smart contract Parameters(Used while calling smart contract)
+   * @param scInitParam : Smart contract initialization parameters.
+   */
   mkDelegatedLsig: (
-    name: string, // ASC filename
-    scParams: LogicSigArgs, // Parameters
+    name: string,
     signer: Account,
-    scInitParam?: Object
+    scParams: LogicSigArgs,
+    scInitParam?: unknown
   ) => Promise<LsigInfo>
+
+  /**
+   * Description: Make delegated logic signature signed by signer
+   * @param approvalProgram: approval program filename (must be present in assets folder)
+   * @param clearProgram: clear program filename (must be present in assets folder)
+   * @param flags: SSCDeploymentFlags
+   * @param payFlags: Transaction Parameters
+   * @param scInitParam : Smart contract initialization parameters.
+   */
   deploySSC: (
     approvalProgram: string,
     clearProgram: string,
     flags: SSCDeploymentFlags,
     payFlags: TxParams,
-    scInitParam?: Object) => Promise<SSCInfo>
+    scInitParam?: unknown) => Promise<SSCInfo>
+
   /**
      Returns true if ASA or DelegatedLsig or SSC were deployed in any script.
      Checks even for checkpoints which are out of scope from the execution
      session and are not obtainable using get methods.
   */
   isDefined: (name: string) => boolean
+
+  // map for storing ASA
   asa: Map<string, ASAInfo>
 
   // These functions are exposed only for users.
@@ -537,11 +575,21 @@ export interface AlgobDeployer {
   // get delegated Logic signature
   getDelegatedLsig: (lsigName: string) => Object | undefined
 
-  // load contract mode logic signature
-  loadLogic: (name: string, scParams: LogicSigArgs) => Promise<LogicSig>
+  /**
+   * Description: Load Logic signature from a file
+   * @param name:  Smart Contract filename (must be present in assets folder)
+   * @param scParams: Smart contract Parameters(Used while calling smart contract)
+   * @param scInitParam : Smart contract initialization parameters.
+   */
+  loadLogic: (name: string, scParams: LogicSigArgs, scInitParam?: unknown) => Promise<LogicSig>
 
-  // returns compiled program
-  ensureCompiled: (name: string, force: boolean) => Promise<ASCCache>
+  /**
+   * Description: Returns ASCCache (with compiled code)
+   * @param name: Smart Contract filename (must be present in assets folder)
+   * @param force: if force is true file will be compiled for sure, even if it's checkpoint exist
+   * @param scInitParam: Smart contract initialization parameters.
+   */
+  ensureCompiled: (name: string, force?: boolean, scInitParam?: unknown) => Promise<ASCCache>
 }
 
 // ************************

--- a/packages/algob/src/types.ts
+++ b/packages/algob/src/types.ts
@@ -492,18 +492,21 @@ export interface AlgobDeployer {
     name: string, // ASC filename
     scParams: LogicSigArgs, // Parameters
     flags: FundASCFlags,
-    payFlags: TxParams
+    payFlags: TxParams,
+    scInitParam?: Object
   ) => void
   mkDelegatedLsig: (
     name: string, // ASC filename
     scParams: LogicSigArgs, // Parameters
-    signer: Account
+    signer: Account,
+    scInitParam?: Object
   ) => Promise<LsigInfo>
   deploySSC: (
     approvalProgram: string,
     clearProgram: string,
     flags: SSCDeploymentFlags,
-    payFlags: TxParams) => Promise<SSCInfo>
+    payFlags: TxParams,
+    scInitParam?: Object) => Promise<SSCInfo>
   /**
      Returns true if ASA or DelegatedLsig or SSC were deployed in any script.
      Checks even for checkpoints which are out of scope from the execution

--- a/packages/algob/test/fixture-projects/scripts-dir-recursive-cp/scripts/2.js
+++ b/packages/algob/test/fixture-projects/scripts-dir-recursive-cp/scripts/2.js
@@ -1,6 +1,6 @@
 async function run (runtimeEnv, deployer) {
   if (deployer.isDeployMode) {
-    await deployer.fundLsig('fee-check.teal', {}, { funder: deployer.accounts[0], fundingMicroAlgo: 100000000 }, {})
+    await deployer.fundLsig('fee-check.teal', { funder: deployer.accounts[0], fundingMicroAlgo: 100000000 }, {}, [])
   }
 }
 

--- a/packages/algob/test/internal/deployer.ts
+++ b/packages/algob/test/internal/deployer.ts
@@ -213,7 +213,7 @@ describe("DeployerDeployMode", () => {
 
   it("Should not crash when same ASC Contract Mode name is tried to fund second time", async () => {
     const deployer = new DeployerDeployMode(deployerCfg);
-    await deployer.fundLsig("Lsig", [], { funder: deployer.accounts[1], fundingMicroAlgo: 1000 }, {});
+    await deployer.fundLsig("Lsig", { funder: deployer.accounts[1], fundingMicroAlgo: 1000 }, {}, []);
   });
 
   it("Should return empty ASA map on no CP", async () => {

--- a/packages/algob/test/mocks/deployer.ts
+++ b/packages/algob/test/mocks/deployer.ts
@@ -1,4 +1,4 @@
-import type { LogicSig } from "algosdk";
+import type { LogicSig, LogicSigArgs } from "algosdk";
 import * as algosdk from "algosdk";
 
 import type {
@@ -39,7 +39,7 @@ export class FakeDeployer implements AlgobDeployer {
     throw new Error("Not implemented");
   }
 
-  async loadLogic (name: string, scParams: Object): Promise<LogicSig> {
+  async loadLogic (name: string, scParams: LogicSigArgs, scInitParam?: unknown): Promise<LogicSig> {
     throw new Error("Not implemented");
   }
 
@@ -58,11 +58,13 @@ export class FakeDeployer implements AlgobDeployer {
     throw new Error("Not implemented");
   };
 
-  async fundLsig (name: string, scParams: object, flags: FundASCFlags): Promise<void> {
+  async fundLsig (name: string, flags: FundASCFlags,
+    payFlags: TxParams, scParams: LogicSigArgs, scInitParam?: unknown): Promise<void> {
     throw new Error("Not implemented");
   }
 
-  async mkDelegatedLsig (name: string, scParams: object, signer: Account): Promise<LsigInfo> {
+  async mkDelegatedLsig (name: string, signer: Account,
+    scParams: LogicSigArgs, scInitParam?: unknown): Promise<LsigInfo> {
     throw new Error("Not implemented");
   }
 
@@ -74,7 +76,7 @@ export class FakeDeployer implements AlgobDeployer {
     throw new Error("Not implemented");
   }
 
-  async ensureCompiled (name: string, force: boolean): Promise<ASCCache> {
+  async ensureCompiled (name: string, force?: boolean, scInitParam?: unknown): Promise<ASCCache> {
     throw new Error("Not implemented");
   }
 

--- a/packages/algob/test/stubs/algo-operator.ts
+++ b/packages/algob/test/stubs/algo-operator.ts
@@ -1,5 +1,5 @@
 import type { LogicSig } from "algosdk";
-import { Algodv2 } from "algosdk";
+import { Algodv2, LogicSigArgs } from "algosdk";
 
 import { txWriter } from "../../src/internal/tx-log-writer";
 import { AlgoOperator } from "../../src/lib/algo-operator";
@@ -42,8 +42,8 @@ export class AlgoOperatorDryRunImpl implements AlgoOperator {
   }
 
   async fundLsig (
-    name: string, scParams: Object, flags: FundASCFlags, payFlags: TxParams,
-    txnWriter: txWriter): Promise<LsigInfo> {
+    name: string, flags: FundASCFlags, payFlags: TxParams,
+    txnWriter: txWriter, scParams: LogicSigArgs, scInitParam?: unknown): Promise<LsigInfo> {
     return {
       creator: flags.funder.addr + "-get-address-dry-run",
       contractAddress: "dfssdfsd",
@@ -56,7 +56,8 @@ export class AlgoOperatorDryRunImpl implements AlgoOperator {
     clearProgram: string,
     flags: SSCDeploymentFlags,
     payFlags: TxParams,
-    txWriter: txWriter): Promise<SSCInfo> {
+    txWriter: txWriter,
+    scInitParam?: unknown): Promise<SSCInfo> {
     return {
       creator: flags.sender.addr + "-get-address-dry-run",
       txId: "tx-id-dry-run",
@@ -65,7 +66,7 @@ export class AlgoOperatorDryRunImpl implements AlgoOperator {
     };
   }
 
-  async ensureCompiled (name: string, force: boolean): Promise<ASCCache> {
+  async ensureCompiled (name: string, force?: boolean, scInitParam?: unknown): Promise<ASCCache> {
     return {
       filename: name,
       timestamp: 1010, // compilation time (Unix time)


### PR DESCRIPTION
`scInitParam` Object can be passed from scripts.

- This param is taken as Object and then converted into string using yaml.stringify.
- passed to python scripts
- decoded in python scripts

We cannot determine the type of user input for smart contract initialization paramerers, so `type` of `scInitParam` is `Object`.

dynamic-fee example is updated to show how we can pass initialization param.