### PR TITLE
Interpreter scratch op

### DIFF
--- a/packages/algorand-js/src/interpreter/interpreter.ts
+++ b/packages/algorand-js/src/interpreter/interpreter.ts
@@ -3,7 +3,7 @@ import { assert } from "chai";
 
 import { TealError } from "../errors/errors";
 import { ERRORS } from "../errors/errors-list";
-import { DEFAULT_STACKELEM } from "../lib/constants";
+import { DEFAULT_STACK_ELEM } from "../lib/constants";
 import { Stack } from "../lib/stack";
 import type { Operator, StackElem, TEALStack } from "../types";
 
@@ -17,7 +17,7 @@ export class Interpreter {
     this.stack = new Stack<StackElem>();
     this.bytecblock = [];
     this.intcblock = [];
-    this.scratch = new Array(256).fill(DEFAULT_STACKELEM);
+    this.scratch = new Array(256).fill(DEFAULT_STACK_ELEM);
   }
 
   /**

--- a/packages/algorand-js/src/interpreter/interpreter.ts
+++ b/packages/algorand-js/src/interpreter/interpreter.ts
@@ -3,6 +3,7 @@ import { assert } from "chai";
 
 import { TealError } from "../errors/errors";
 import { ERRORS } from "../errors/errors-list";
+import { DEFAULT_STACKELEM } from "../lib/constants";
 import { Stack } from "../lib/stack";
 import type { Operator, StackElem, TEALStack } from "../types";
 
@@ -10,11 +11,13 @@ export class Interpreter {
   readonly stack: TEALStack;
   bytecblock: Uint8Array[];
   intcblock: Array<bigint>;
+  scratch: StackElem[];
 
   constructor () {
     this.stack = new Stack<StackElem>();
     this.bytecblock = [];
     this.intcblock = [];
+    this.scratch = new Array(256).fill(DEFAULT_STACKELEM);
   }
 
   /**

--- a/packages/algorand-js/src/interpreter/interpreter.ts
+++ b/packages/algorand-js/src/interpreter/interpreter.ts
@@ -10,7 +10,7 @@ import type { Operator, StackElem, TEALStack } from "../types";
 export class Interpreter {
   readonly stack: TEALStack;
   bytecblock: Uint8Array[];
-  intcblock: Array<bigint>;
+  intcblock: BigInt[];
   scratch: StackElem[];
 
   constructor () {

--- a/packages/algorand-js/src/interpreter/opcode-list.ts
+++ b/packages/algorand-js/src/interpreter/opcode-list.ts
@@ -1,6 +1,7 @@
 import { TealError } from "../errors/errors";
 import { ERRORS } from "../errors/errors-list";
-import type { TEALStack } from "../types";
+import { DEFAULT_STACKELEM } from "../lib/constants";
+import type { StackElem, TEALStack } from "../types";
 import { Interpreter } from "./interpreter";
 import { Op } from "./opcode";
 
@@ -149,5 +150,42 @@ export class Intc extends Op {
     this.checkIndexBound(this.index, this.interpreter.intcblock);
     const intc = this.assertBigInt(this.interpreter.intcblock[this.index]);
     stack.push(intc);
+  }
+}
+
+// pop a value from the stack and store to scratch space
+export class Store extends Op {
+  readonly index: number;
+  readonly interpreter: Interpreter;
+
+  constructor (index: number, interpreter: Interpreter) { // eslint-disable-line sonarjs/no-identical-functions
+    super();
+    this.index = index;
+    this.interpreter = interpreter;
+  }
+
+  execute (stack: TEALStack): void {
+    this.checkIndexBound(this.index, this.interpreter.scratch);
+    this.assertStackLen(stack, 1);
+    const top = stack.pop() as StackElem;
+    this.interpreter.scratch[this.index] = top;
+  }
+}
+
+// copy a value from scratch space to the stack
+export class Load extends Op {
+  readonly index: number;
+  readonly interpreter: Interpreter;
+
+  constructor (index: number, interpreter: Interpreter) { // eslint-disable-line sonarjs/no-identical-functions
+    super();
+    this.index = index;
+    this.interpreter = interpreter;
+  }
+
+  execute (stack: TEALStack): void {
+    this.checkIndexBound(this.index, this.interpreter.scratch);
+    const val = this.interpreter.scratch[this.index];
+    stack.push(val);
   }
 }

--- a/packages/algorand-js/src/interpreter/opcode-list.ts
+++ b/packages/algorand-js/src/interpreter/opcode-list.ts
@@ -1,3 +1,4 @@
+/* eslint sonarjs/no-identical-functions: 0 */
 import { TealError } from "../errors/errors";
 import { ERRORS } from "../errors/errors-list";
 import type { TEALStack } from "../types";
@@ -157,7 +158,7 @@ export class Store extends Op {
   readonly index: number;
   readonly interpreter: Interpreter;
 
-  constructor (index: number, interpreter: Interpreter) { // eslint-disable-line sonarjs/no-identical-functions
+  constructor (index: number, interpreter: Interpreter) {
     super();
     this.index = index;
     this.interpreter = interpreter;
@@ -176,7 +177,7 @@ export class Load extends Op {
   readonly index: number;
   readonly interpreter: Interpreter;
 
-  constructor (index: number, interpreter: Interpreter) { // eslint-disable-line sonarjs/no-identical-functions
+  constructor (index: number, interpreter: Interpreter) {
     super();
     this.index = index;
     this.interpreter = interpreter;

--- a/packages/algorand-js/src/interpreter/opcode-list.ts
+++ b/packages/algorand-js/src/interpreter/opcode-list.ts
@@ -1,7 +1,6 @@
 import { TealError } from "../errors/errors";
 import { ERRORS } from "../errors/errors-list";
-import { DEFAULT_STACKELEM } from "../lib/constants";
-import type { StackElem, TEALStack } from "../types";
+import type { TEALStack } from "../types";
 import { Interpreter } from "./interpreter";
 import { Op } from "./opcode";
 

--- a/packages/algorand-js/src/interpreter/opcode-list.ts
+++ b/packages/algorand-js/src/interpreter/opcode-list.ts
@@ -167,7 +167,7 @@ export class Store extends Op {
   execute (stack: TEALStack): void {
     this.checkIndexBound(this.index, this.interpreter.scratch);
     this.assertStackLen(stack, 1);
-    const top = stack.pop() as StackElem;
+    const top = stack.pop();
     this.interpreter.scratch[this.index] = top;
   }
 }

--- a/packages/algorand-js/src/interpreter/opcode.ts
+++ b/packages/algorand-js/src/interpreter/opcode.ts
@@ -22,13 +22,13 @@ export class Op {
     }
   }
 
-  checkIndexBound (idx: number, arr: Array<Uint8Array | bigint>): void {
+  checkIndexBound (idx: number, arr: Array<Uint8Array | BigInt>): void {
     if (!(idx >= 0 && idx < arr.length)) {
       throw new TealError(ERRORS.TEAL.INDEX_OUT_OF_BOUND);
     }
   }
 
-  assertArrLength (arr: Uint8Array[] | Array<bigint>): void {
+  assertArrLength (arr: Uint8Array[] | BigInt[]): void {
     if (!arr.length || arr.length > MAX_UINT8 + 1) {
       throw new TealError(ERRORS.TEAL.ASSERT_ARR_LENGTH);
     }

--- a/packages/algorand-js/src/lib/constants.ts
+++ b/packages/algorand-js/src/lib/constants.ts
@@ -3,3 +3,4 @@ export const MAX_UINT64 = BigInt("18446744073709551615");
 export const MIN_UINT64 = BigInt("0");
 export const MAX_UINT8 = 255;
 export const MIN_UINT8 = 0;
+export const DEFAULT_STACKELEM = BigInt("0");

--- a/packages/algorand-js/src/lib/stack.ts
+++ b/packages/algorand-js/src/lib/stack.ts
@@ -1,6 +1,6 @@
 export interface IStack<T> {
   push: (item: T) => void
-  pop: () => T | undefined
+  pop: () => T
   length: () => number
 }
 
@@ -20,10 +20,10 @@ export class Stack<T> implements IStack<T> {
     this._store.push(item);
   }
 
-  pop (): T | undefined {
+  pop (): T {
     if (this.length() === 0) {
       throw new Error(`Stack UnderFlow - Cannot pop if stack is empty`);
     }
-    return this._store.pop();
+    return this._store.pop() as T;
   }
 }

--- a/packages/algorand-js/src/lib/stack.ts
+++ b/packages/algorand-js/src/lib/stack.ts
@@ -15,14 +15,14 @@ export class Stack<T> implements IStack<T> {
 
   push (item: T): void {
     if (this.length() === this.capacity) {
-      throw new Error(`Stack Overflow - Cannot push more items than max capacity ${this.capacity}`);
+      throw new Error(`Stack overflow: cannot push more items than max capacity ${this.capacity}`);
     }
     this._store.push(item);
   }
 
   pop (): T {
     if (this.length() === 0) {
-      throw new Error(`Stack UnderFlow - Cannot pop if stack is empty`);
+      throw new Error("pop from empty stack");
     }
     return this._store.pop() as T;
   }

--- a/packages/algorand-js/test/src/interpreter/interpreter.ts
+++ b/packages/algorand-js/test/src/interpreter/interpreter.ts
@@ -14,7 +14,7 @@ const fkParam = {
 };
 
 describe("Interpreter", function () {
-  it("should throw error if top of stack is invalid", function () {
+  it("should reject logic if top of stack is invalid", function () {
     const interpreter = new Interpreter();
     const args = [toBytes("")];
     const logic = [new Arg(args[0])];

--- a/packages/algorand-js/test/src/interpreter/opcode-list.ts
+++ b/packages/algorand-js/test/src/interpreter/opcode-list.ts
@@ -8,7 +8,7 @@ import {
   Intcblock, Len, Load,
   Mul, Store, Sub
 } from "../../../src/interpreter/opcode-list";
-import { DEFAULT_STACKELEM, MAX_UINT8, MAX_UINT64 } from "../../../src/lib/constants";
+import { DEFAULT_STACK_ELEM, MAX_UINT8, MAX_UINT64 } from "../../../src/lib/constants";
 import { toBytes } from "../../../src/lib/parse-data";
 import { Stack } from "../../../src/lib/stack";
 import type { StackElem } from "../../../src/types";
@@ -497,7 +497,7 @@ describe("Teal Opcodes", function () {
       const interpreter = new Interpreter();
       const op = new Load(0, interpreter);
       op.execute(stack);
-      assert.equal(DEFAULT_STACKELEM, stack.pop());
+      assert.equal(DEFAULT_STACK_ELEM, stack.pop());
     });
   });
 });

--- a/packages/algorand-js/test/src/interpreter/opcode-list.ts
+++ b/packages/algorand-js/test/src/interpreter/opcode-list.ts
@@ -5,9 +5,10 @@ import { Interpreter } from "../../../src/interpreter/interpreter";
 import {
   Add, Arg, Bytec,
   Bytecblock, Div, Intc,
-  Intcblock, Len, Mul, Sub
+  Intcblock, Len, Load,
+  Mul, Store, Sub
 } from "../../../src/interpreter/opcode-list";
-import { MAX_UINT8, MAX_UINT64 } from "../../../src/lib/constants";
+import { DEFAULT_STACKELEM, MAX_UINT8, MAX_UINT64 } from "../../../src/lib/constants";
 import { toBytes } from "../../../src/lib/parse-data";
 import { Stack } from "../../../src/lib/stack";
 import type { StackElem } from "../../../src/types";
@@ -410,6 +411,93 @@ describe("Teal Opcodes", function () {
         () => op.execute(stack),
         ERRORS.TEAL.INDEX_OUT_OF_BOUND
       );
+    });
+  });
+
+  describe("Store", function () {
+    const stack = new Stack<StackElem>();
+
+    it("should store uint64 to scratch", function () {
+      const interpreter = new Interpreter();
+      const val = BigInt("0");
+      stack.push(val);
+
+      const op = new Store(0, interpreter);
+      op.execute(stack);
+      assert.equal(stack.length(), 0); // verify stack is popped
+      assert.equal(val, interpreter.scratch[0]);
+    });
+
+    it("should store byte[] to scratch", function () {
+      const interpreter = new Interpreter();
+      const val = toBytes("HelloWorld");
+      stack.push(val);
+
+      const op = new Store(0, interpreter);
+      op.execute(stack);
+      assert.equal(stack.length(), 0); // verify stack is popped
+      assert.equal(val, interpreter.scratch[0]);
+    });
+
+    it("should throw error on store if index is out of bound", function () {
+      const interpreter = new Interpreter();
+      stack.push(BigInt("0"));
+
+      const op = new Store(MAX_UINT8 + 5, interpreter);
+      expectTealError(
+        () => op.execute(stack),
+        ERRORS.TEAL.INDEX_OUT_OF_BOUND
+      );
+    });
+
+    it("should throw error on store if stack is empty", function () {
+      const interpreter = new Interpreter();
+      const stack = new Stack<StackElem>(); // empty stack
+      const op = new Store(0, interpreter);
+      expectTealError(
+        () => op.execute(stack),
+        ERRORS.TEAL.ASSERT_STACK_LENGTH
+      );
+    });
+  });
+
+  describe("Load", function () {
+    const stack = new Stack<StackElem>();
+    const interpreter = new Interpreter();
+    const scratch = [BigInt("0"), toBytes("HelloWorld")];
+    interpreter.scratch = scratch;
+
+    it("should load uint64 from scratch space to stack", function () {
+      const op = new Load(0, interpreter);
+      const len = stack.length();
+
+      op.execute(stack);
+      assert.equal(len + 1, stack.length()); // verify stack is pushed
+      assert.equal(interpreter.scratch[0], stack.pop());
+    });
+
+    it("should load byte[] from scratch space to stack", function () {
+      const op = new Load(1, interpreter);
+      const len = stack.length();
+
+      op.execute(stack);
+      assert.equal(len + 1, stack.length()); // verify stack is pushed
+      assert.equal(interpreter.scratch[1], stack.pop());
+    });
+
+    it("should throw error on load if index is out of bound", function () {
+      const op = new Load(MAX_UINT8 + 5, interpreter);
+      expectTealError(
+        () => op.execute(stack),
+        ERRORS.TEAL.INDEX_OUT_OF_BOUND
+      );
+    });
+
+    it("should load default value to stack if value at a slot is not intialized", function () {
+      const interpreter = new Interpreter();
+      const op = new Load(0, interpreter);
+      op.execute(stack);
+      assert.equal(DEFAULT_STACKELEM, stack.pop());
     });
   });
 });

--- a/packages/algorand-js/test/src/interpreter/stack.ts
+++ b/packages/algorand-js/test/src/interpreter/stack.ts
@@ -10,7 +10,7 @@ describe("Stack", function () {
   });
 
   it("should throw error while popping empty stack", function () {
-    const errMsg = "Stack UnderFlow - Cannot pop if stack is empty";
+    const errMsg = "pop from empty stack";
     assert.throws(() => stack.pop(), errMsg);
   });
 


### PR DESCRIPTION
- Added classes `Store`, `Load`
- Added tests

NOTE:
+ `load x` does not throw error if nothing is stored is scratch. Some default value is loaded to stack. I tested that using 
```
load 1
load 2
+
```
The logic fails. But teal is compiled and run successfully.
