### PR TITLE
example nft: fix conditions and parameters

### DIFF
--- a/examples/nft/README.md
+++ b/examples/nft/README.md
@@ -3,20 +3,18 @@
 In this example, we create a new non-fungible-token represented by a name and a ref.
 Compared to standard ASA, in this example we create a smart-contract to manage and store NFT balances.
 
-- Each NFT is an `(ID, ref_data, hash)` triple, stored in the smart contract as `{id: ref_data, id_h: hash}` mapping.
+- Each NFT is an `(ID, data_ref, hash)` triple, stored in the smart contract as `{id: data_ref, id_h: hash}` mapping.
 - `id` is the NFT ID which is calculated as: `total_count_of_nft + 1`. Eg: `id = 1` for the first nft in the smart contract.
-- `ref_data` is associated reference data. Ideally the `ref_data` should be an external URL. Eg: `ref_data` = `https://nft.com/1/ref`.
-- `id_h` is a `sha256` hash of  the content of reference data.
+- `data_ref` is associated reference data. Ideally the `data_ref` should be an external URL. Eg: `data_ref` = `https://nft.com/1/ref`.
+- `hash` is a hash of the content of referenced data (eg: content of the data at the URL).
 
 Please check smart contract for the available commands and arguments to the smart contract.
 
-NOTE:
-* An account can hold upto a maximum of 8 NFT's in it's local storage.
-* The NFT smart contract can hold a maximum of 32 NFT's (in global storage)
-* _**This is only a proof of concept**. In production use we need to handle properly the account which can manage the smart-contract (update or delete)_.
+NOTES:
+* A smart contract can create up to 32 NFTs and an account can hold up to 16 NFT's in it's local storage. This is because the ASC can store a maximum of 16 values (`int`) in user account local storage and 64 values (`int/[]byte`)  in the global storage. Read more about state storage [here](https://developer.algorand.org/docs/features/asc1/stateful/sdks/#state-storage).
+* _**This is only a proof of concept**. In production use we need to handle properly the account which can manage the smart-contract (update or delete)_ and audit all conditions.
 * In this ASC, Update Application call is **blocked** i.e once deployed, you cannot update the smart contract by another program. Refer to [this](https://developer.algorand.org/docs/features/asc1/stateful/#update-stateful-smart-contract) for more details.
 
-This is because the ASC can store a maximum of 16 values (`int/[]byte`) in user account local storage and 64 values (`int/[]byte`)  in the global storage. Read more about state storage [here](https://developer.algorand.org/docs/features/asc1/stateful/sdks/#state-storage).
 
 ## Setup
 

--- a/examples/nft/assets/nft_approval.py
+++ b/examples/nft/assets/nft_approval.py
@@ -9,72 +9,68 @@ def approval_program():
     hash is an hash of the external resources data.
 
     Commands:
-        create    Creates a new NFT. Expects one additional argument: nft-ref
-                  Only creator can create new NFTs. Ideally, nft-ref should be a URL.
-        transfer  Transfers an NFT between two accounts. Expects one additional arg: NFT_ID.
+      create    Creates a new NFT. Expects 2 additional arguments:
+                * nft-ref: a reference data (usually an URL or CID)
+                * nft-ref-hash: a hash of the underlying reference data
+                Only creator can create new NFTs.
+      transfer  Transfers an NFT between two accounts. Expects one additional arg: NFT_ID.
                   Additionally, two Accounts(from, to) must also be passed to the smart contract.
     """
 
     var_total = Bytes("total")
+    var_1 = Int(1)
 
     # Check to see that the application ID is not set, indicating this is a creation call.
     # Store the creator address to global state.
     # Set total nft count to 0
-    on_creation = Seq([
+    on_deployment = Seq([
         App.globalPut(Bytes("creator"), Txn.sender()),
         Assert(Txn.application_args.length() == Int(0)),
         App.globalPut(var_total, Int(0)),
-        Return(Int(1))
+        Return(var_1)
     ])
 
     # Always verify that the RekeyTo property of any transaction is set to the ZeroAddress
     # unless the contract is specifically involved ina rekeying operation.
     no_rekey_addr = Txn.rekey_to() == Global.zero_address()
 
-	# Checks whether the sender is creator.
+    # Checks whether the sender is creator.
     is_creator = Txn.sender() == App.globalGet(Bytes("creator"))
 
     # Get total amount of NFT's from global storage
-    nft_id = Itob(App.globalGet(var_total))
+    create_nft_id = Itob(App.globalGet(var_total))
 
-    # ref_data is a reference data of the NFT, usually an URL or CID.
-    # nft-hash = hash of ref-data
-    ref_data = Txn.application_args[1]
-    ref_hash = Sha256(Txn.application_args[1])
+    # create transaction parameters
+    data_ref = Txn.application_args[1]
+    data_hash = Txn.application_args[2]
 
-    # var to store ref_hash
     # var to store id_h
-    scratch_hash = ScratchVar(TealType.bytes)
     id_h = ScratchVar(TealType.bytes)
 
     # Verifies if the creater is making this request
     # Verifies three arguments are passed to this transaction ("create", nft-name, nft-ref)
     # Increment Global NFT count by 1
-    # Assign ref_data to NFT ID (= total)
+    # Assign data_ref to NFT ID (= total)
     # Assign hash of nft-ref to ID_h
     # Add above two keys to global and creator's local storage
     create_nft = Seq([
         Assert(And(
-            Txn.application_args.length() == Int(2),
+            Txn.application_args.length() == Int(3),
             is_creator,
             no_rekey_addr
         )),
 
-        App.globalPut(var_total, App.globalGet(var_total) + Int(1)),
+        id_h.store(Concat(create_nft_id, Bytes("_h"))), # store id_h in scratchVar
 
-        scratch_hash.store(ref_hash), # store ref_hash in scratchVar
-        id_h.store(Concat(nft_id, Bytes("_h"))), # store id_h in scratchVar
+        App.globalPut(var_total, App.globalGet(var_total) + var_1),
+        App.globalPut(create_nft_id, data_ref),
+        App.globalPut(id_h.load() , data_hash),
 
-        App.globalPut(nft_id, ref_data),
-        App.globalPut(id_h.load() , scratch_hash.load()),
-
-        App.localPut(Int(0), nft_id, ref_data),  # Int(0) represents the address of caller
-        App.localPut(Int(0), id_h.load() , scratch_hash.load()),
+        App.localPut(Int(0), create_nft_id, var_1),  # Int(0) represents the address of caller
         Return(is_creator)
     ])
 
-    # nft-hash key from 1st argument
-    id_h = Concat(Txn.application_args[1], Bytes("_h"))
+    transfer_nft_id = Txn.application_args[1]  # this is only in the transfer condition
 
     # Verify two arguments are passed
     # Verify NFT_ID is present in global storage
@@ -83,30 +79,28 @@ def approval_program():
     transfer_nft = Seq([
         Assert(And(
             Txn.application_args.length() == Int(2),
-            App.globalGet(var_total) >= Btoi(Txn.application_args[1]),
-            no_rekey_addr
+            no_rekey_addr,
+            # assert that a account_1 holds the NFT
+            App.localGet(var_1, transfer_nft_id) == var_1
         )),
 
-        App.localPut(Int(2), Txn.application_args[1], App.localGet(Int(1), Txn.application_args[1])),
-        App.localPut(Int(2), id_h, App.localGet(Int(1), id_h)),
-
-        App.localDel(Int(1), Txn.application_args[1]),
-        App.localDel(Int(1), id_h),
-        Return(Int(1))
+        App.localDel(var_1, transfer_nft_id),
+        App.localPut(Int(2), transfer_nft_id, var_1),
+        Return(var_1)
     ])
 
-    # Verfies that the application_id is 0, jumps to on_creation.
+    # Verfies that the application_id is 0, jumps to on_deployment.
     # Verifies that DeleteApplication is used and verifies that sender is creator.
     # Verifies that UpdateApplication is used and blocks that call (unsafe for production use).
     # Verifies that closeOut is used and jumps to on_closeout.
     # Verifies that the account has opted in and jumps to on_register.
     # Verifies that first argument is "vote" and jumps to on_vote.
     program = Cond(
-        [Txn.application_id() == Int(0), on_creation],
+        [Txn.application_id() == Int(0), on_deployment],
         [Txn.on_completion() == OnComplete.UpdateApplication, Return(Int(0))], #block update
         [Txn.on_completion() == OnComplete.DeleteApplication, Return(is_creator)],
-        [Txn.on_completion() == OnComplete.CloseOut, Return(Int(1))],
-        [Txn.on_completion() == OnComplete.OptIn, Return(Int(1))],
+        [Txn.on_completion() == OnComplete.CloseOut, Return(var_1)],
+        [Txn.on_completion() == OnComplete.OptIn, Return(var_1)],
         [Txn.application_args[0] == Bytes("create"), create_nft],
         [Txn.application_args[0] == Bytes("transfer"), transfer_nft]
     )

--- a/examples/nft/assets/nft_approval.py
+++ b/examples/nft/assets/nft_approval.py
@@ -60,9 +60,9 @@ def approval_program():
             no_rekey_addr
         )),
 
-        id_h.store(Concat(create_nft_id, Bytes("_h"))), # store id_h in scratchVar
-
         App.globalPut(var_total, App.globalGet(var_total) + var_1),
+
+        id_h.store(Concat(create_nft_id, Bytes("_h"))), # store id_h in scratchVar
         App.globalPut(create_nft_id, data_ref),
         App.globalPut(id_h.load() , data_hash),
 

--- a/examples/nft/assets/nft_approval.py
+++ b/examples/nft/assets/nft_approval.py
@@ -10,7 +10,7 @@ def approval_program():
 
     Commands:
       create    Creates a new NFT. Expects 2 additional arguments:
-                * nft-ref: a reference data (usually an URL or CID)
+                * nft-ref: a reference data (usually a URL or CID)
                 * nft-ref-hash: a hash of the underlying reference data
                 Only creator can create new NFTs.
       transfer  Transfers an NFT between two accounts. Expects one additional arg: NFT_ID.

--- a/examples/nft/scripts/deploy-nft.js
+++ b/examples/nft/scripts/deploy-nft.js
@@ -23,8 +23,7 @@ async function run(runtimeEnv, deployer) {
 
   await deployer.deploySSC("nft_approval.py", "nft_clear_state.py", {
     sender: masterAccount,
-    localInts: 8,
-    localBytes: 8,
+    localInts: 16,
     globalInts: 1,
     globalBytes: 63
   }, {});

--- a/examples/nft/scripts/transfer/common.js
+++ b/examples/nft/scripts/transfer/common.js
@@ -25,13 +25,11 @@ exports.printGlobalNFT = async function (deployer, creator, appId) {
 exports.printLocalNFT = async function (deployer, account, appId) {
     try {
         const localState = await readLocalStateSSC(deployer, account, appId);
+        // each nft is stored as a one record in user store
         let count = 0;
-
-        // length/2 because each nft is a pair of {id: ref_data, id_h: ref_hash}
-        if(localState !== undefined){ 
-            count = localState.length/2; 
-        }
-        console.log('NFT balance of', account, ':', count); 
+        if (localState !== undefined)
+            count = localState.length
+        console.log('NFT balance of', account, ':', count);
     } catch (e) {
         console.error('Error Occurred', e);
     }

--- a/examples/nft/scripts/transfer/create-transfer-nft.js
+++ b/examples/nft/scripts/transfer/create-transfer-nft.js
@@ -39,7 +39,7 @@ async function run(runtimeEnv, deployer) {
   await printLocalNFT(deployer, masterAccount.addr, appId);
   await printLocalNFT(deployer, john.addr, appId);
 
-  let nftID = new Uint8Array(8).fill(2, 7); // [0, 0, 0, 0, 0, 0, 0, 1] = uint64(1)
+  let nftID = new Uint8Array(8).fill(1, 7); // [0, 0, 0, 0, 0, 0, 0, 1] = uint64(1)
   appArgs = [
     toBytes("transfer"),
     nftID,

--- a/examples/nft/scripts/transfer/create-transfer-nft.js
+++ b/examples/nft/scripts/transfer/create-transfer-nft.js
@@ -39,8 +39,8 @@ async function run(runtimeEnv, deployer) {
   await printLocalNFT(deployer, masterAccount.addr, appId);
   await printLocalNFT(deployer, john.addr, appId);
 
-  let nftID = new Uint8Array(8).fill(1, 7), // [0, 0, 0, 0, 0, 0, 0, 1] = uint64(1)
-  appArgs2 = [
+  let nftID = new Uint8Array(8).fill(2, 7); // [0, 0, 0, 0, 0, 0, 0, 1] = uint64(1)
+  appArgs = [
     toBytes("transfer"),
     nftID,
   ];
@@ -54,7 +54,7 @@ async function run(runtimeEnv, deployer) {
     appId: appId,
     payFlags: {},
     accounts: [masterAccount.addr, john.addr],
-    appArgs2
+    appArgs
   };
   await executeTransaction(deployer, txnParam);
 

--- a/examples/nft/scripts/transfer/create-transfer-nft.js
+++ b/examples/nft/scripts/transfer/create-transfer-nft.js
@@ -18,8 +18,8 @@ async function run(runtimeEnv, deployer) {
 
   const nft_ref = "https://new-nft.com";
 
-  // push arguments "create" and nft data
-  let appArgs = ["create", nft_ref].map(toBytes);
+  // arguments: "create", nft_data_ref, data_hash
+  let appArgs = ["create", nft_ref, "1234"].map(toBytes);
 
   let txnParam = {
     type: TransactionType.CallNoOpSSC,
@@ -37,12 +37,12 @@ async function run(runtimeEnv, deployer) {
   // *** Transfer NFT from master to john ***
 
   await printLocalNFT(deployer, masterAccount.addr, appId);
-  await printLocalNFT(deployer, johnAccount.addr, appId);
+  await printLocalNFT(deployer, john.addr, appId);
 
-  // push arguments: ("transfer", nft_id=1)
-  appArgs = [
+  let nftID = new Uint8Array(8).fill(1, 7), // [0, 0, 0, 0, 0, 0, 0, 1] = uint64(1)
+  appArgs2 = [
     toBytes("transfer"),
-    new Uint8Array(8).fill(1, 7), //[0, 0, 0, 0, 0, 0, 0, 1]
+    nftID,
   ];
 
   // transfer nft from master to john
@@ -54,12 +54,12 @@ async function run(runtimeEnv, deployer) {
     appId: appId,
     payFlags: {},
     accounts: [masterAccount.addr, john.addr],
-    appArgs
+    appArgs2
   };
   await executeTransaction(deployer, txnParam);
 
   await printLocalNFT(deployer, masterAccount.addr, appId);
-  await printLocalNFT(deployer, johnAccount.addr, appId);
+  await printLocalNFT(deployer, john.addr, appId);
 }
 
 module.exports = { default: run }


### PR DESCRIPTION
The local storage was wrongly defined:

1. we don't need to store ref_data hash - it's enough to store it only once in global state
2. local state should only have information which NFT IDs the user has - we can store it as a {nft_id: 1}.