### PR TITLE
Add more TEAL opcodes

### DIFF
--- a/packages/algob/test/builtin-tasks/compile.ts
+++ b/packages/algob/test/builtin-tasks/compile.ts
@@ -168,7 +168,7 @@ describe("Support External Parameters in PyTEAL program", () => {
     assert.equal(op.timestamp, 2);
     assert.lengthOf(op.compiledFiles, 0);
     assert.lengthOf(op.writtenFiles, 0);
-  
+
     // On third run, should compile on third run because external parameters passed
     result = await pyOp.ensureCompiled(stateless, false, scInitParam);
     const newStatelessHash = result.srcHash;

--- a/packages/algorand-js/src/errors/errors-list.ts
+++ b/packages/algorand-js/src/errors/errors-list.ts
@@ -48,14 +48,14 @@ incorrect. Expected %expected% but got %actual%`
     number: 5,
     message: "Result of current operation caused integer overflow",
     title: "Uint64 Overflow",
-    description: `You are tying to perform operation where the result has exceeded 
+    description: `You are tying to perform operation where the result has exceeded
 maximun uint64 value of 18446744073709551615`
   },
   UINT64_UNDERFLOW: {
     number: 6,
     message: "Result of current operation caused integer underflow",
     title: "Uint64 Underflow",
-    description: `You are tying to perform operation where the result is less than 
+    description: `You are tying to perform operation where the result is less than
 minimum uint64 value of 0`
   },
   ZERO_DIV: {
@@ -75,7 +75,7 @@ non zero value or []byte`
     number: 9,
     message: "Index out of bound",
     title: "Index out of bound",
-    description: `Segmentation fault - The teal code tried to access a value 
+    description: `Segmentation fault - The teal code tried to access a value
 by an index that does not exist.`
   },
   TEAL_ENCOUNTERED_ERR: {
@@ -107,6 +107,12 @@ by an index that does not exist.`
     message: "substring range beyond length of string",
     title: "substring range beyond length of string",
     description: `substring range beyond length of string.`
+  },
+  INVALID_UINT8: {
+    number: 15,
+    message: "Input is not uint8",
+    title: "Input is outside the valid uint8 range of 0 to 255",
+    description: `Input is outside the valid uint8 range of 0 to 255`
   }
 };
 

--- a/packages/algorand-js/src/interpreter/opcode-list.ts
+++ b/packages/algorand-js/src/interpreter/opcode-list.ts
@@ -587,7 +587,6 @@ export class Substring3 extends Op {
 }
 
 /** Pseudo-Ops **/
-
 // push integer to stack
 export class Int extends Op {
   readonly uint64: bigint;

--- a/packages/algorand-js/src/interpreter/opcode.ts
+++ b/packages/algorand-js/src/interpreter/opcode.ts
@@ -1,6 +1,6 @@
 import { TealError } from "../errors/errors";
 import { ERRORS } from "../errors/errors-list";
-import { MAX_UINT8, MAX_UINT64, MIN_UINT64 } from "../lib/constants";
+import { MAX_UINT8, MAX_UINT64, MIN_UINT8, MIN_UINT64 } from "../lib/constants";
 import type { TEALStack } from "../types";
 
 export class Op {
@@ -52,5 +52,23 @@ export class Op {
       });
     }
     return b;
+  }
+
+  assertUint8 (a: bigint): bigint {
+    if (a < MIN_UINT8 || a > MAX_UINT8) {
+      throw new TealError(ERRORS.TEAL.INVALID_UINT8);
+    }
+    return a;
+  }
+
+  subString (start: bigint, end: bigint, byteString: Uint8Array): Uint8Array {
+    if (end < start) {
+      throw new TealError(ERRORS.TEAL.SUBSTRING_END_BEFORE_START);
+    }
+    if (start > byteString.length || end > byteString.length) {
+      throw new TealError(ERRORS.TEAL.SUBSTRING_RANGE_BEYOND);
+    }
+
+    return byteString.slice(Number(start), Number(end));
   }
 }

--- a/packages/algorand-js/src/lib/parse-data.ts
+++ b/packages/algorand-js/src/lib/parse-data.ts
@@ -1,3 +1,7 @@
+import * as base32 from "hi-base32";
+
+import { EncodingType } from "../types";
+
 // parse string to Uint8Array
 export function toBytes (s: string): Uint8Array {
   return new Uint8Array(Buffer.from(s));
@@ -6,4 +10,21 @@ export function toBytes (s: string): Uint8Array {
 // parse Uint8Array to string
 export function convertToString (u: Uint8Array): string {
   return Buffer.from(u).toString('utf-8');
+}
+
+export function convertToBuffer (s: string, encoding?: EncodingType): Buffer {
+  switch (encoding) {
+    case EncodingType.BASE64: {
+      return Buffer.from(s, 'base64');
+    }
+    case EncodingType.BASE32: {
+      return Buffer.from(base32.decode(s));
+    }
+    case EncodingType.HEX: {
+      return Buffer.from(s, 'hex');
+    }
+    default: { // default encoding (utf-8)
+      return Buffer.from(s);
+    }
+  }
 }

--- a/packages/algorand-js/src/types.ts
+++ b/packages/algorand-js/src/types.ts
@@ -10,3 +10,9 @@ export type AppArgs = Array<string | number>;
 
 export type StackElem = bigint | Uint8Array;
 export type TEALStack = IStack<bigint | Uint8Array>;
+
+export enum EncodingType {
+  BASE64,
+  BASE32,
+  HEX
+}

--- a/packages/algorand-js/test/src/interpreter/opcode-list.ts
+++ b/packages/algorand-js/test/src/interpreter/opcode-list.ts
@@ -4,15 +4,16 @@ import { assert } from "chai";
 import { ERRORS } from "../../../src/errors/errors-list";
 import { Interpreter } from "../../../src/interpreter/interpreter";
 import {
-  Add, Addw, And, Arg, BitwiseAnd, BitwiseNot, BitwiseOr, BitwiseXor,
-  Btoi, Bytec, Bytecblock, Concat, Div, Dup, Dup2,
-  EqualTo, Err, GreaterThan, GreaterThanEqualTo, Intc,
+  Add, Addr,
+  Addw, And, Arg, BitwiseAnd, BitwiseNot, BitwiseOr, BitwiseXor,
+  Btoi, Byte, Bytec, Bytecblock, Concat, Div, Dup, Dup2,
+  EqualTo, Err, GreaterThan, GreaterThanEqualTo, Int, Intc,
   Intcblock, Itob,
   Len, LessThan, LessThanEqualTo,
-  Load,
-  Mod, Mul, Not, NotEqualTo, Or, Sha256, Sha512_256, Store, Sub, Substring3
+  Load, Mod, Mul, Mulw, Not, NotEqualTo, Or, Sha256, Sha512_256, Store, Sub, Substring,
+  Substring3
 } from "../../../src/interpreter/opcode-list";
-import { DEFAULT_STACK_ELEM, MAX_UINT8, MAX_UINT64 } from "../../../src/lib/constants";
+import { DEFAULT_STACK_ELEM, MAX_UINT8, MAX_UINT64, MIN_UINT8 } from "../../../src/lib/constants";
 import { convertToString, toBytes } from "../../../src/lib/parse-data";
 import { Stack } from "../../../src/lib/stack";
 import type { StackElem } from "../../../src/types";
@@ -1055,6 +1056,64 @@ describe("Teal Opcodes", function () {
     });
   });
 
+  describe("Mulw", () => {
+    const stack = new Stack<StackElem>();
+
+    it("should return correct low and high value", () => {
+      stack.push(BigInt('4581298449'));
+      stack.push(BigInt('9162596898'));
+      const op = new Mulw();
+      op.execute(stack);
+
+      const low = stack.pop();
+      const high = stack.pop();
+      assert.equal(low, BigInt('5083102810200507970'));
+      assert.equal(high, BigInt('2'));
+    });
+
+    it("high bits should be 0", () => {
+      stack.push(BigInt('10'));
+      stack.push(BigInt('3'));
+      const op = new Mulw();
+      op.execute(stack);
+
+      const low = stack.pop();
+      const high = stack.pop();
+      assert.equal(low, BigInt('30'));
+      assert.equal(high, BigInt('0'));
+    });
+
+    it("low and high should be 0 on a*b if a or b is 0", () => {
+      stack.push(BigInt('0'));
+      stack.push(BigInt('3'));
+      const op = new Mulw();
+      op.execute(stack);
+
+      const low = stack.pop();
+      const high = stack.pop();
+      assert.equal(low, BigInt('0'));
+      assert.equal(high, BigInt('0'));
+    });
+
+    it("should throw stack length error",
+      execExpectError(
+        stack,
+        [BigInt('3')],
+        new Mulw(),
+        ERRORS.TEAL.ASSERT_STACK_LENGTH
+      )
+    );
+
+    it("should throw error if type is invalid",
+      execExpectError(
+        stack,
+        ["str1", "str2"].map(toBytes),
+        new Mulw(),
+        ERRORS.TEAL.INVALID_TYPE
+      )
+    );
+  });
+
   describe("Dup", () => {
     const stack = new Stack<StackElem>();
 
@@ -1118,7 +1177,81 @@ describe("Teal Opcodes", function () {
     });
   });
 
-  describe("substring3", function () {
+  describe("Substring", function () {
+    const stack = new Stack<StackElem>();
+    const start = BigInt('0');
+    const end = BigInt('4');
+
+    it("should return correct substring", function () {
+      stack.push(toBytes("Algorand"));
+      const op = new Substring(start, end);
+      op.execute(stack);
+
+      const top = stack.pop() as Uint8Array;
+      assert.equal("Algo", convertToString(top));
+    });
+
+    it("should throw Invalid type error",
+      execExpectError(
+        stack,
+        [BigInt('1')],
+        new Substring(start, end),
+        ERRORS.TEAL.INVALID_TYPE
+      )
+    );
+
+    it("should throw error if start is not uint8", function () {
+      execExpectError(
+        stack,
+        [toBytes("Algorand")],
+        new Substring(BigInt(MIN_UINT8 - 5), end),
+        ERRORS.TEAL.INVALID_UINT8
+      );
+
+      execExpectError(
+        stack,
+        [toBytes("Algorand")],
+        new Substring(BigInt(MAX_UINT8 + 5), end),
+        ERRORS.TEAL.INVALID_UINT8
+      );
+    });
+
+    it("should throw error if end is not uint8", function () {
+      execExpectError(
+        stack,
+        [toBytes("Algorand")],
+        new Substring(start, BigInt(MIN_UINT8 - 5)),
+        ERRORS.TEAL.INVALID_UINT8
+      );
+
+      execExpectError(
+        stack,
+        [toBytes("Algorand")],
+        new Substring(start, BigInt(MAX_UINT8 + 5)),
+        ERRORS.TEAL.INVALID_UINT8
+      );
+    });
+
+    it("should throw error because start > end",
+      execExpectError(
+        stack,
+        [toBytes("Algorand")],
+        new Substring(end + BigInt('5'), end),
+        ERRORS.TEAL.SUBSTRING_END_BEFORE_START
+      )
+    );
+
+    it("should throw error because range beyong string",
+      execExpectError(
+        stack,
+        [toBytes("Algorand")],
+        new Substring(start, start + BigInt('40')),
+        ERRORS.TEAL.SUBSTRING_RANGE_BEYOND
+      )
+    );
+  });
+
+  describe("Substring3", function () {
     const stack = new Stack<StackElem>();
 
     it("should return correct substring", function () {
@@ -1133,34 +1266,59 @@ describe("Teal Opcodes", function () {
       assert.equal("Algo", convertToString(top));
     });
 
-    it("should throw Invalid type error", function () {
-      stack.push(BigInt('4'));
-      stack.push(BigInt('0'));
-      stack.push(BigInt('1234'));
-
-      const op = new Substring3();
-      expectTealError(
-        () => op.execute(stack),
+    it("should throw Invalid type error",
+      execExpectError(
+        stack,
+        ['4', '0', '1234'].map(BigInt),
+        new Substring3(),
         ERRORS.TEAL.INVALID_TYPE
+      )
+    );
+
+    it("should throw error because start > end", function () {
+      const end = BigInt('4');
+      const start = end + BigInt('1');
+      execExpectError(
+        stack,
+        [end, start, toBytes("Algorand")],
+        new Substring3(),
+        ERRORS.TEAL.SUBSTRING_END_BEFORE_START
       );
     });
 
-    it("should throw error because start > end", function () {
-      stack.push(BigInt('4'));
-      stack.push(BigInt('5'));
-      stack.push(toBytes("Algorand"));
+    it("should throw error because range beyong string",
+      execExpectError(
+        stack,
+        [BigInt('40'), BigInt('0'), toBytes("Algorand")],
+        new Substring3(),
+        ERRORS.TEAL.SUBSTRING_RANGE_BEYOND
+      )
+    );
+  });
 
-      const op = new Substring3();
-      assert.throws(() => op.execute(stack), "substring end before start");
+  describe("Pseudo-Ops", function () {
+    const stack = new Stack<StackElem>();
+
+    it("Int - should push uint64 to stack", function () {
+      const op = new Int(MAX_UINT64);
+      op.execute(stack);
+
+      assert.equal(1, stack.length());
+      assert.equal(MAX_UINT64, stack.pop());
     });
 
-    it("should throw error because range beyong string", function () {
-      stack.push(BigInt('40'));
-      stack.push(BigInt('0'));
-      stack.push(toBytes("Algorand"));
+    it("Byte/Addr - should push byte[] to stack", function () {
+      const byte = toBytes("Algorand");
 
-      const op = new Substring3();
-      assert.throws(() => op.execute(stack), "substring range beyond length of string");
+      const byteOp = new Byte(byte);
+      byteOp.execute(stack);
+      assert.equal(1, stack.length());
+      assert.equal(byte, stack.pop());
+
+      const addrOp = new Addr(byte);
+      addrOp.execute(stack);
+      assert.equal(1, stack.length());
+      assert.equal(byte, stack.pop());
     });
   });
 });

--- a/packages/algorand-js/test/src/interpreter/opcode-list.ts
+++ b/packages/algorand-js/test/src/interpreter/opcode-list.ts
@@ -1201,7 +1201,7 @@ describe("Teal Opcodes", function () {
       op.execute(stack);
 
       const top = stack.pop();
-      assert.equal(Buffer.from("Algo"), top);
+      assert.deepEqual(Buffer.from("Algo"), top);
     });
 
     it("should throw Invalid type error",
@@ -1276,7 +1276,7 @@ describe("Teal Opcodes", function () {
       op.execute(stack);
 
       const top = stack.pop();
-      assert.equal(Buffer.from("Algo"), top);
+      assert.deepEqual(Buffer.from("Algo"), top);
     });
 
     it("should throw Invalid type error",

--- a/packages/algorand-js/test/src/interpreter/opcode-list.ts
+++ b/packages/algorand-js/test/src/interpreter/opcode-list.ts
@@ -1071,6 +1071,18 @@ describe("Teal Opcodes", function () {
       assert.equal(high, BigInt('2'));
     });
 
+    it("should return correct low and high value on big numbers", () => {
+      stack.push(MAX_UINT64 - BigInt('2'));
+      stack.push(BigInt('9162596898'));
+      const op = new Mulw();
+      op.execute(stack);
+
+      const low = stack.pop();
+      const high = stack.pop();
+      assert.equal(low, BigInt('18446744046221760922'));
+      assert.equal(high, BigInt('9162596897'));
+    });
+
     it("high bits should be 0", () => {
       stack.push(BigInt('10'));
       stack.push(BigInt('3'));

--- a/packages/algorand-js/test/src/interpreter/opcode-list.ts
+++ b/packages/algorand-js/test/src/interpreter/opcode-list.ts
@@ -15,7 +15,7 @@ import {
   Substring3
 } from "../../../src/interpreter/opcode-list";
 import { DEFAULT_STACK_ELEM, MAX_UINT8, MAX_UINT64, MIN_UINT8 } from "../../../src/lib/constants";
-import { convertToBuffer, convertToString, toBytes } from "../../../src/lib/parse-data";
+import { convertToBuffer, toBytes } from "../../../src/lib/parse-data";
 import { Stack } from "../../../src/lib/stack";
 import { EncodingType, StackElem } from "../../../src/types";
 import { execExpectError, expectTealError } from "../../helpers/errors";
@@ -1200,8 +1200,8 @@ describe("Teal Opcodes", function () {
       const op = new Substring(start, end);
       op.execute(stack);
 
-      const top = stack.pop() as Uint8Array;
-      assert.equal("Algo", convertToString(top));
+      const top = stack.pop();
+      assert.equal(Buffer.from("Algo"), top);
     });
 
     it("should throw Invalid type error",
@@ -1275,8 +1275,8 @@ describe("Teal Opcodes", function () {
       const op = new Substring3();
       op.execute(stack);
 
-      const top = stack.pop() as Uint8Array;
-      assert.equal("Algo", convertToString(top));
+      const top = stack.pop();
+      assert.equal(Buffer.from("Algo"), top);
     });
 
     it("should throw Invalid type error",


### PR DESCRIPTION
- Added opcodes: `substring`, `mulw`, `Int`, `Byte`, `Addr`
- Added tests