### PR TITLE
Interpreter - Add transaction context

### DIFF
--- a/packages/algob/src/index.ts
+++ b/packages/algob/src/index.ts
@@ -9,11 +9,12 @@ import { globalZeroAddress } from "./lib/constants";
 import { algodCredentialsFromEnv, KMDCredentialsFromEnv } from "./lib/credentials";
 import { toBytes, update } from "./lib/ssc";
 import { balanceOf, printAssets, printGlobalStateSSC, printLocalStateSSC, readGlobalStateSSC, readLocalStateSSC } from "./lib/status";
-import { executeSignedTxnFromFile, executeTransaction } from "./lib/tx";
+import { executeSignedTxnFromFile, executeTransaction, mkTransaction } from "./lib/tx";
 import { SignType, TransactionType } from "./types";
 
 export {
   mkAccounts,
+  mkTransaction,
   createMsigAddress,
   loadAccountsFromFile,
   loadAccountsFromFileSync,

--- a/packages/algorand-js/src/interpreter/interpreter.ts
+++ b/packages/algorand-js/src/interpreter/interpreter.ts
@@ -53,10 +53,10 @@ export class Interpreter {
   /**
    * Description: this function executes set of Operator[] passed after
    * parsing teal code
-   * @param {execParams} txn : Transaction parameters for current txn
-   * @param {Logic[]} logic : set of Logic objects
-   * @param {AppArgs} args : argument array passed to the current transaction
-   * @returns {boolean} : transaction accepted/rejected based on asc logic
+   * @param {execParams} txn : Transaction parameters
+   * @param {Logic[]} logic : smart contract instructions
+   * @param {AppArgs} args : external arguments
+   * @returns {boolean} : transaction accepted/rejected based on ASC logic
    */
   execute (txnParams: execParams | execParams[], logic: Operator[], args: Uint8Array[]): boolean {
     assert(Array.isArray(args));

--- a/packages/algorand-js/src/interpreter/interpreter.ts
+++ b/packages/algorand-js/src/interpreter/interpreter.ts
@@ -1,6 +1,9 @@
+import { mkTransaction } from "algob";
 import type { execParams } from "algob/src/types";
+import { assignGroupID, Transaction } from "algosdk";
 import { assert } from "chai";
 
+import { mockSuggestedParams } from "../../test/mocks/txn";
 import { TealError } from "../errors/errors";
 import { ERRORS } from "../errors/errors-list";
 import { DEFAULT_STACK_ELEM } from "../lib/constants";
@@ -12,24 +15,53 @@ export class Interpreter {
   bytecblock: Uint8Array[];
   intcblock: BigInt[];
   scratch: StackElem[];
+  txnContext: Transaction | Transaction[];
 
   constructor () {
     this.stack = new Stack<StackElem>();
     this.bytecblock = [];
     this.intcblock = [];
     this.scratch = new Array(256).fill(DEFAULT_STACK_ELEM);
+    this.txnContext = [];
   }
 
   /**
- * Description: this function executes set of Operator[] passed after
- * parsing teal code
- * @param {execParams} txn : Transaction parameters for current txn
- * @param {Logic[]} logic : set of Logic objects
- * @param {AppArgs} args : argument array passed to the current transaction
- * @returns {boolean} : transaction accepted/rejected based on asc logic
- */
-  execute (txn: execParams, logic: Operator[], args: Uint8Array[]): boolean {
+   * Description: creates a new transaction object from given execParams
+   * @param  txnParams : Transaction parameters for current txn or txn Group
+   * @returns Transaction object
+   */
+  createTxnContext (txnParams: execParams | execParams[]): Transaction | Transaction[] {
+    if (Array.isArray(txnParams)) {
+      if (txnParams.length > 16) {
+        throw new Error("Maximum size of an atomic transfer group is 16");
+      }
+
+      const txns = [];
+      for (const txnParam of txnParams) {
+        const mockParams = mockSuggestedParams(txnParam.payFlags);
+        const txn = mkTransaction(txnParam, mockParams);
+        txns.push(txn);
+      }
+      assignGroupID(txns);
+      return txns;
+    } else {
+      const mockParams = mockSuggestedParams(txnParams.payFlags);
+      return mkTransaction(txnParams, mockParams);
+    }
+  }
+
+  /**
+   * Description: this function executes set of Operator[] passed after
+   * parsing teal code
+   * @param {execParams} txn : Transaction parameters for current txn
+   * @param {Logic[]} logic : set of Logic objects
+   * @param {AppArgs} args : argument array passed to the current transaction
+   * @returns {boolean} : transaction accepted/rejected based on asc logic
+   */
+  execute (txnParams: execParams | execParams[], logic: Operator[], args: Uint8Array[]): boolean {
     assert(Array.isArray(args));
+    this.txnContext = this.createTxnContext(txnParams);
+
     for (const l of logic) {
       l.execute(this.stack); // execute each teal opcode
     }

--- a/packages/algorand-js/src/types.ts
+++ b/packages/algorand-js/src/types.ts
@@ -1,3 +1,5 @@
+import { AccountInfo } from "algosdk";
+
 import {
   Add, Arg, Bytec, Bytecblock, Div, Len, Mul, Sub
 } from "./interpreter/opcode-list";
@@ -120,4 +122,8 @@ export enum EncodingType {
   BASE64,
   BASE32,
   HEX
+}
+
+export interface AccountsMap {
+  [addr: string]: AccountInfo
 }

--- a/packages/algorand-js/src/types.ts
+++ b/packages/algorand-js/src/types.ts
@@ -95,11 +95,13 @@ export enum GlobalField {
   CurrentApplicationID // ID of current application executing. Fails if no such application is executing.
 }
 
+// will be mapped to a specific account
 export enum AssetHolding {
   AssetBalance, // Amount of the asset unit held by this account
   AssetFrozen // Is the asset frozen or not
 }
 
+// this is for global storage
 export enum AssetParam {
   AssetTotal, // Total number of units of this asset
   AssetDecimals, // See AssetParams.Decimals

--- a/packages/algorand-js/src/types.ts
+++ b/packages/algorand-js/src/types.ts
@@ -11,6 +11,109 @@ export type AppArgs = Array<string | number>;
 export type StackElem = bigint | Uint8Array;
 export type TEALStack = IStack<bigint | Uint8Array>;
 
+// https://developer.algorand.org/docs/reference/teal/opcodes/#txn
+export enum TxnField {
+  Sender, // 32 byte address
+  Fee, // micro-Algos
+  FirstValid, // round number
+  FirstValidTime,
+  LastValid, // round number
+  Note,
+  Lease,
+  Receiver, // 32 byte address
+  Amount, // micro-Algos
+  CloseRemainderTo, // 32 byte address
+  VotePK, // 32 byte address
+  SelectionPK, // 32 byte address
+  VoteFirst,
+  VoteLast,
+  VoteKeyDilution,
+  Type,
+  TypeEnum,
+  XferAsset, // Asset ID
+  AssetAmount, // value in Asset's units
+  AssetSender, // 32 byte address. Causes clawback of all value of asset from AssetSender if Sender is the Clawback address of the asset.
+  AssetReceiver, // 32 byte address
+  AssetCloseTo, // 32 byte address
+  GroupIndex, // Position of this transaction within an atomic transaction group. A stand-alone transaction is implicitly element 0 in a group of 1
+  TxID, // The computed ID for this transaction. 32 bytes.
+  ApplicationID, // ApplicationID from ApplicationCall transaction.
+  OnCompletion, // ApplicationCall transaction on completion action.
+  ApplicationArgs, // Arguments passed to the application in the ApplicationCall transaction.
+  NumAppArgs, // Number of ApplicationArgs.
+  Accounts, // Accounts listed in the ApplicationCall transaction.
+  NumAccounts, // Number of Accounts
+  ApprovalProgram, // Approval program
+  ClearStateProgram, // Clear state program
+  RekeyTo, // 32 byte Sender's new AuthAddr
+  ConfigAsset, // Asset ID in asset config transaction
+  ConfigAssetTotal, // Total number of units of this asset created
+  ConfigAssetDecimals, // Number of digits to display after the decimal place when displaying the asset
+  ConfigAssetDefaultFrozen, // Whether the asset's slots are frozen by default or not, 0 or 1
+  ConfigAssetUnitName, // Unit name of the asset
+  ConfigAssetName, // The asset name
+  ConfigAssetURL, // URL
+  ConfigAssetMetadataHash, // 32 byte commitment to some unspecified asset metadata
+  ConfigAssetManager, // 32 byte address
+  ConfigAssetReserve, // 32 byte address
+  ConfigAssetFreeze, // 32 byte address
+  ConfigAssetClawback, // 32 byte address
+  FreezeAsset, // Asset ID being frozen or un-frozen
+  FreezeAssetAccount, // 32 byte address of the account whose asset slot is being frozen or un-frozen.
+  FreezeAssetFrozen // The new frozen value, 0 or 1
+}
+
+export enum TxnType {
+  unknown, // Unknown type. Invalid transaction
+  pay, // Payment
+  keyreg, // KeyRegistration
+  acfg, // AssetConfig
+  axfer, // AssetTransfer
+  afrz, // AssetFreeze
+  appl // ApplicationCall
+}
+
+// https://developer.algorand.org/docs/reference/teal/specification/#oncomplete
+export enum TxnOnComplete {
+  NoOp,
+  OptIn,
+  CloseOut,
+  ClearState,
+  UpdateApplication,
+  DeleteApplication
+}
+
+export enum GlobalField {
+  MinTxnFee, // micro Algos
+  MinBalance, // micro Algos
+  MaxTxnLife, // rounds
+  ZeroAddress, // 32 byte address of all zero bytes
+  GroupSize, // Number of transactions in this atomic transaction group. At least 1
+  LogicSigVersion, // Maximum supported TEAL version.
+  Round, // Current round number
+  LatestTimestamp, // Last confirmed block UNIX timestamp. Fails if negative.
+  CurrentApplicationID // ID of current application executing. Fails if no such application is executing.
+}
+
+export enum AssetHolding {
+  AssetBalance, // Amount of the asset unit held by this account
+  AssetFrozen // Is the asset frozen or not
+}
+
+export enum AssetParam {
+  AssetTotal, // Total number of units of this asset
+  AssetDecimals, // See AssetParams.Decimals
+  AssetDefaultFrozen, // Frozen by default or not
+  AssetUnitName, // Asset unit name
+  AssetName, // Asset name
+  AssetURL, // URL with additional info about the asset
+  AssetMetadataHash, // Arbitrary commitment
+  AssetManager, // Manager commitment
+  AssetReserve, // Reserve address
+  AssetFreeze, // Freeze address
+  AssetClawback // Clawback address
+}
+
 export enum EncodingType {
   BASE64,
   BASE32,

--- a/packages/algorand-js/test/mocks/txn.ts
+++ b/packages/algorand-js/test/mocks/txn.ts
@@ -1,0 +1,25 @@
+import { TxParams } from "algob/src/types";
+import type { SuggestedParams } from "algosdk";
+
+const ALGORAND_MIN_TX_FEE = 1000;
+const GENESIS_ID = 'testnet-v1.0';
+// testnet-v1.0 hash
+const GENESIS_HASH = 'SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=';
+
+export function mockSuggestedParams (
+  payFlags: TxParams): SuggestedParams {
+  const s = {} as SuggestedParams;
+
+  s.flatFee = payFlags.totalFee !== undefined;
+  s.fee = payFlags.totalFee ?? payFlags.feePerByte ?? ALGORAND_MIN_TX_FEE;
+  if (s.flatFee) s.fee = Math.max(s.fee, ALGORAND_MIN_TX_FEE);
+
+  s.firstRound = payFlags.firstValid ?? 1;
+  s.lastRound = payFlags.firstValid === undefined || payFlags.validRounds === undefined
+    ? s.firstRound + 1000
+    : payFlags.firstValid + payFlags.validRounds;
+
+  s.genesisID = GENESIS_ID;
+  s.genesisHash = GENESIS_HASH;
+  return s;
+}

--- a/packages/algorand-js/test/src/interpreter/interpreter.ts
+++ b/packages/algorand-js/test/src/interpreter/interpreter.ts
@@ -7,9 +7,12 @@ import { expectTealError } from "../../helpers/errors";
 const fkParam = {
   type: 0,
   sign: 0,
-  fromAccount: { addr: '', sk: new Uint8Array(0) },
-  to: '',
-  appId: 0,
+  fromAccount: {
+    addr: 'EDXG4GGBEHFLNX6A7FGT3F6Z3TQGIU6WVVJNOXGYLVNTLWDOCEJJ35LWJY',
+    sk: new Uint8Array(0)
+  },
+  toAccountAddr: '2ILRL5YU3FZ4JDQZQVXEZUYKEWF7IEIGRRCPCMI36VKSGDMAS6FHSBXZDQ',
+  amountMicroAlgos: 100,
   payFlags: {}
 };
 

--- a/packages/algorand-js/test/src/interpreter/interpreter.ts
+++ b/packages/algorand-js/test/src/interpreter/interpreter.ts
@@ -1,3 +1,5 @@
+import { generateAccount } from "algosdk";
+
 import { ERRORS } from "../../../src/errors/errors-list";
 import { Interpreter } from "../../../src/interpreter/interpreter";
 import { Arg } from "../../../src/interpreter/opcode-list";
@@ -7,10 +9,7 @@ import { expectTealError } from "../../helpers/errors";
 const fkParam = {
   type: 0,
   sign: 0,
-  fromAccount: {
-    addr: 'EDXG4GGBEHFLNX6A7FGT3F6Z3TQGIU6WVVJNOXGYLVNTLWDOCEJJ35LWJY',
-    sk: new Uint8Array(0)
-  },
+  fromAccount: generateAccount(),
   toAccountAddr: '2ILRL5YU3FZ4JDQZQVXEZUYKEWF7IEIGRRCPCMI36VKSGDMAS6FHSBXZDQ',
   amountMicroAlgos: 100,
   payFlags: {}

--- a/packages/algorand-js/test/src/interpreter/interpreter.ts
+++ b/packages/algorand-js/test/src/interpreter/interpreter.ts
@@ -21,7 +21,7 @@ describe("Interpreter", function () {
     const args = [toBytes("")];
     const logic = [new Arg(args[0])];
     expectTealError(
-      () => interpreter.execute(fkParam, logic, args),
+      () => interpreter.execute(fkParam, logic, args, []),
       ERRORS.TEAL.LOGIC_REJECTION
     );
   });


### PR DESCRIPTION
- Added context for transaction using `mkTransaction`
- Added types for `Transaction` (`fields`, `type`, `oncomplete`), `Assets` (`holdings`, `params`) 

NOTE: Will be adding context for state related data with stateful opcodes. 