### PR TITLE
Update pseudo-op int

### DIFF
--- a/packages/algorand-js/src/interpreter/opcode-list.ts
+++ b/packages/algorand-js/src/interpreter/opcode-list.ts
@@ -1893,7 +1893,7 @@ export class Int extends Op {
 
     let uint64;
     const txOnComplete = TxnOnComplete[args[0] as keyof typeof TxnOnComplete]; // eg. TxnOnComplete['NoOp']
-    if (txOnComplete !== undefined && typeof txOnComplete === 'number') { // check if string is keyof TxnOnComplete Enum
+    if (txOnComplete !== undefined) { // check if string is keyof TxnOnComplete Enum
       uint64 = BigInt(txOnComplete);
     } else {
       assertOnlyDigits(args[0]);

--- a/packages/algorand-js/src/interpreter/opcode-list.ts
+++ b/packages/algorand-js/src/interpreter/opcode-list.ts
@@ -1892,9 +1892,9 @@ export class Int extends Op {
     assertLen(args.length, 1, line);
 
     let uint64;
-    if (Object.values(TxnOnComplete).includes(args[0])) { // check if string is keyof TxnOnComplete Enum
-      uint64 = TxnOnComplete[args[0] as keyof typeof TxnOnComplete]; // eg. TxnOnComplete['NoOp']
-      uint64 = BigInt(uint64);
+    const txOnComplete = TxnOnComplete[args[0] as keyof typeof TxnOnComplete]; // eg. TxnOnComplete['NoOp']
+    if (txOnComplete !== undefined && typeof txOnComplete === 'number') { // check if string is keyof TxnOnComplete Enum
+      uint64 = BigInt(txOnComplete);
     } else {
       assertOnlyDigits(args[0]);
       uint64 = BigInt(args[0]);

--- a/packages/algorand-js/src/interpreter/opcode-list.ts
+++ b/packages/algorand-js/src/interpreter/opcode-list.ts
@@ -1901,7 +1901,6 @@ export class Int extends Op {
     }
 
     this.checkOverflow(uint64);
-    this.checkUnderflow(uint64);
     this.uint64 = uint64;
   }
 

--- a/packages/algorand-js/src/interpreter/opcode-list.ts
+++ b/packages/algorand-js/src/interpreter/opcode-list.ts
@@ -13,7 +13,7 @@ import { checkIndexBound, compareArray } from "../lib/compare";
 import { AssetParamMap, GlobalFields, MAX_CONCAT_SIZE, MAX_UINT64 } from "../lib/constants";
 import { assertLen, assertOnlyDigits, convertToBuffer, convertToString, getEncoding } from "../lib/parsing";
 import { txAppArg, txnSpecbyField } from "../lib/txn";
-import type { EncodingType, StackElem, TEALStack } from "../types";
+import { EncodingType, StackElem, TEALStack, TxnOnComplete } from "../types";
 import { Interpreter } from "./interpreter";
 import { Op } from "./opcode";
 
@@ -1722,76 +1722,6 @@ export class AppGlobalDel extends Op {
   }
 }
 
-/** Pseudo-Ops **/
-// push integer to stack
-// push to stack [...stack, integer value]
-export class Int extends Op {
-  readonly uint64: bigint;
-
-  /**
-   * Description: Sets uint64 variable according to arguments passed.
-   * @param args Expected arguments: [number]
-   * @param line line number in TEAL file
-   */
-  constructor (args: string[], line: number) {
-    super();
-    assertLen(args.length, 1, line);
-    assertOnlyDigits(args[0]);
-    this.uint64 = BigInt(args[0]);
-  }
-
-  execute (stack: TEALStack): void {
-    stack.push(this.uint64);
-  }
-}
-
-// push bytes to stack
-// push to stack [...stack, converted data]
-export class Byte extends Op {
-  readonly str: string;
-  readonly encoding: EncodingType;
-
-  /**
-   * Description: Sets `str` and  `encoding` values according to arguments passed.
-   * @param args Expected arguments: [data string]
-   * @param line line number in TEAL file
-   */
-  constructor (args: string[], line: number) {
-    super();
-    [this.str, this.encoding] = getEncoding(args, line);
-  }
-
-  execute (stack: TEALStack): void {
-    const buffer = convertToBuffer(this.str, this.encoding);
-    stack.push(new Uint8Array(buffer));
-  }
-}
-
-// decodes algorand address to bytes and pushes to stack
-// push to stack [...stack, address]
-export class Addr extends Op {
-  readonly addr: string;
-
-  /**
-   * Description: Sets `addr` value according to arguments passed.
-   * @param args Expected arguments: [Address]
-   * @param line line number in TEAL file
-   */
-  constructor (args: string[], line: number) {
-    super();
-    assertLen(args.length, 1, line);
-    if (!isValidAddress(args[0])) {
-      throw new TealError(ERRORS.TEAL.INVALID_ADDR, { addr: args[0], line: line });
-    }
-    this.addr = args[0];
-  };
-
-  execute (stack: TEALStack): void {
-    const addr = decodeAddress(this.addr);
-    stack.push(addr.publicKey);
-  }
-}
-
 // get balance for the requested account specified
 // by Txn.Accounts[A] in microalgos. A is specified as an account
 // index in the Accounts field of the ApplicationCall transaction,
@@ -1943,5 +1873,86 @@ export class GetAssetDef extends Op {
       stack.push(value);
       stack.push(BigInt("1"));
     }
+  }
+}
+
+/** Pseudo-Ops **/
+// push integer to stack
+// push to stack [...stack, integer value]
+export class Int extends Op {
+  readonly uint64: bigint;
+
+  /**
+   * Description: Sets uint64 variable according to arguments passed.
+   * @param args Expected arguments: [number]
+   * @param line line number in TEAL file
+   */
+  constructor (args: string[], line: number) {
+    super();
+    assertLen(args.length, 1, line);
+
+    let uint64;
+    if (Object.values(TxnOnComplete).includes(args[0])) { // check if string is keyof TxnOnComplete Enum
+      uint64 = TxnOnComplete[args[0] as keyof typeof TxnOnComplete]; // eg. TxnOnComplete['NoOp']
+      uint64 = BigInt(uint64);
+    } else {
+      assertOnlyDigits(args[0]);
+      uint64 = BigInt(args[0]);
+    }
+
+    this.checkOverflow(uint64);
+    this.checkUnderflow(uint64);
+    this.uint64 = uint64;
+  }
+
+  execute (stack: TEALStack): void {
+    stack.push(this.uint64);
+  }
+}
+
+// push bytes to stack
+// push to stack [...stack, converted data]
+export class Byte extends Op {
+  readonly str: string;
+  readonly encoding: EncodingType;
+
+  /**
+   * Description: Sets `str` and  `encoding` values according to arguments passed.
+   * @param args Expected arguments: [data string]
+   * @param line line number in TEAL file
+   */
+  constructor (args: string[], line: number) {
+    super();
+    [this.str, this.encoding] = getEncoding(args, line);
+  }
+
+  execute (stack: TEALStack): void {
+    const buffer = convertToBuffer(this.str, this.encoding);
+    stack.push(new Uint8Array(buffer));
+  }
+}
+
+// decodes algorand address to bytes and pushes to stack
+// push to stack [...stack, address]
+export class Addr extends Op {
+  readonly addr: string;
+
+  /**
+   * Description: Sets `addr` value according to arguments passed.
+   * @param args Expected arguments: [Address]
+   * @param line line number in TEAL file
+   */
+  constructor (args: string[], line: number) {
+    super();
+    assertLen(args.length, 1, line);
+    if (!isValidAddress(args[0])) {
+      throw new TealError(ERRORS.TEAL.INVALID_ADDR, { addr: args[0], line: line });
+    }
+    this.addr = args[0];
+  };
+
+  execute (stack: TEALStack): void {
+    const addr = decodeAddress(this.addr);
+    stack.push(addr.publicKey);
   }
 }

--- a/packages/algorand-js/src/interpreter/opcode.ts
+++ b/packages/algorand-js/src/interpreter/opcode.ts
@@ -56,13 +56,6 @@ export class Op {
     return b;
   }
 
-  // assert if known transaction field is passed
-  assertDefined (str: string): void {
-    if (TxnFields[str] === undefined) {
-      throw new TealError(ERRORS.TEAL.UNKOWN_TRANSACTION_FIELD, { field: str });
-    }
-  }
-
   assertUint8 (a: bigint): bigint {
     if (a < MIN_UINT8 || a > MAX_UINT8) {
       throw new TealError(ERRORS.TEAL.INVALID_UINT8);

--- a/packages/algorand-js/src/types.ts
+++ b/packages/algorand-js/src/types.ts
@@ -98,10 +98,10 @@ export interface StoreAccount {
 
 // https://developer.algorand.org/docs/reference/teal/specification/#oncomplete
 export enum TxnOnComplete {
-  NoOp,
-  OptIn,
-  CloseOut,
-  ClearState,
-  UpdateApplication,
-  DeleteApplication
+  NoOp = '0',
+  OptIn = '1',
+  CloseOut = '2',
+  ClearState = '3',
+  UpdateApplication = '4',
+  DeleteApplication = '5'
 }

--- a/packages/algorand-js/src/types.ts
+++ b/packages/algorand-js/src/types.ts
@@ -95,3 +95,13 @@ export interface StoreAccount {
   getLocalState: (appId: number, key: Uint8Array) => StackElem | undefined
   updateLocalState: (appId: number, key: Uint8Array, value: StackElem) => AppLocalState[]
 }
+
+// https://developer.algorand.org/docs/reference/teal/specification/#oncomplete
+export enum TxnOnComplete {
+  NoOp,
+  OptIn,
+  CloseOut,
+  ClearState,
+  UpdateApplication,
+  DeleteApplication
+}

--- a/packages/algorand-js/test/src/interpreter/opcode-list.ts
+++ b/packages/algorand-js/test/src/interpreter/opcode-list.ts
@@ -2495,6 +2495,38 @@ describe("Teal Opcodes", function () {
       assert.equal(MAX_UINT64, stack.pop());
     });
 
+    it("Int: should push correct TxnOnComplete enum value to stack", function () {
+      let op = new Int(['NoOp'], 0);
+      op.execute(stack);
+      assert.equal(1, stack.length());
+      assert.equal(BigInt('0'), stack.pop());
+
+      op = new Int(['OptIn'], 0);
+      op.execute(stack);
+      assert.equal(1, stack.length());
+      assert.equal(BigInt('1'), stack.pop());
+
+      op = new Int(['CloseOut'], 0);
+      op.execute(stack);
+      assert.equal(1, stack.length());
+      assert.equal(BigInt('2'), stack.pop());
+
+      op = new Int(['ClearState'], 0);
+      op.execute(stack);
+      assert.equal(1, stack.length());
+      assert.equal(BigInt('3'), stack.pop());
+
+      op = new Int(['UpdateApplication'], 0);
+      op.execute(stack);
+      assert.equal(1, stack.length());
+      assert.equal(BigInt('4'), stack.pop());
+
+      op = new Int(['DeleteApplication'], 0);
+      op.execute(stack);
+      assert.equal(1, stack.length());
+      assert.equal(BigInt('5'), stack.pop());
+    });
+
     it("Addr: should push addr to stack", function () {
       const addr = "SOEI4UA72A7ZL5P25GNISSVWW724YABSGZ7GHW5ERV4QKK2XSXLXGXPG5Y";
       const op = new Addr([addr], 0);

--- a/packages/algorand-js/test/src/parser/parser.ts
+++ b/packages/algorand-js/test/src/parser/parser.ts
@@ -13,6 +13,7 @@ import {
   Not, NotEqualTo, Or, Pop, Pragma, Return, Sha256, Sha512_256, Store,
   Sub, Substring, Substring3, Txn, Txna
 } from "../../../src/interpreter/opcode-list";
+import { MAX_UINT64, MIN_UINT64 } from "../../../src/lib/constants";
 import { opcodeFromSentence, parser, wordsFromLine } from "../../../src/parser/parser";
 import { Runtime } from "../../../src/runtime/runtime";
 import { expectTealError } from "../../helpers/errors";
@@ -358,6 +359,16 @@ describe("Parser", function () {
     it("should throw error for invalid number for 'int'", () => {
       expectTealError(
         () => opcodeFromSentence(["int", "123A12"], 1, interpreter),
+        ERRORS.TEAL.INVALID_TYPE
+      );
+
+      expectTealError(
+        () => opcodeFromSentence(["int", String(MAX_UINT64 + BigInt('5'))], 1, interpreter),
+        ERRORS.TEAL.UINT64_OVERFLOW
+      );
+
+      expectTealError(
+        () => opcodeFromSentence(["int", String(MIN_UINT64 - BigInt('5'))], 1, interpreter),
         ERRORS.TEAL.INVALID_TYPE
       );
     });

--- a/packages/types-algosdk/index.d.ts
+++ b/packages/types-algosdk/index.d.ts
@@ -672,7 +672,7 @@ export interface TxnEncodedObj {
 }
 
 // https://developer.algorand.org/docs/reference/teal/specification/#oncomplete
-export enum TxnOnComplete {
+declare enum TxnOnComplete {
   NoOp,
   OptIn,
   CloseOut,


### PR DESCRIPTION
Updated `int` to accept txnOnComplete enum.
added test

NOTE:
+ Other than `int`, `txn OnCompletion` is also using oncomplete enum, but this is already handled during encoding the txn details. (by `tx.get_obj_for_encoding()`) 