### PR TITLE
fix: algosdk type

### DIFF
--- a/packages/algob/src/lib/status.ts
+++ b/packages/algob/src/lib/status.ts
@@ -28,7 +28,7 @@ export async function readGlobalStateSSC (
   appId: number): Promise<SSCStateSchema[] | undefined> {
   const accountInfoResponse = await deployer.algodClient.accountInformation(creator).do();
   for (const app of accountInfoResponse['created-apps']) {
-    if (app.id === appId) { return app.attributes['global-state']; }
+    if (app.id === appId) { return app.params['global-state']; }
   }
   return undefined;
 }

--- a/packages/types-algosdk/index.d.ts
+++ b/packages/types-algosdk/index.d.ts
@@ -579,12 +579,12 @@ export interface AssetHolding {
 
 export interface CreatedApp {
   id: number;
-  attributes: SSCAttributes;
+  params: SSCAttributes;
 }
 
 export interface CreatedAsset {
   index: number;
-  attributes: AssetDef;
+  params: AssetDef;
 }
 
 export interface AppLocalState {


### PR DESCRIPTION
While renaming devUx we updated types in `algosdk` as well. We shouldn't update keys in `@types/algosdk` (they are written as per sdk).