### PR TITLE
Fix local state initialization after opting-in

### DIFF
--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -369,13 +369,15 @@ export class Runtime {
   optInToApp (accountAddr: string, appId: number,
     flags: SSCOptionalFlags, payFlags: TxParams): void {
     const appParams = this.getApp(appId);
-    const account = this.assertAccountDefined(accountAddr, this.store.accounts.get(accountAddr));
     if (appParams) {
       this.createOptInTx(accountAddr, appId, payFlags, flags);
+      this.ctx.state = cloneDeep(this.store);
+      const account = this.assertAccountDefined(accountAddr, this.ctx.state.accounts.get(accountAddr));
+      account.optInToApp(appId, appParams);
+
       // Execute approval program for Opt-In
       this.run(this.getProgram(appId).approvalProgram, ExecutionMode.STATEFUL);
-
-      account.optInToApp(appId, appParams);
+      this.store = this.ctx.state;
     } else {
       throw new TealError(ERRORS.TEAL.APP_NOT_FOUND, { appId: appId, line: 'unknown' });
     }

--- a/packages/runtime/test/fixtures/stateful/assets/counter-approval.teal
+++ b/packages/runtime/test/fixtures/stateful/assets/counter-approval.teal
@@ -51,5 +51,9 @@ int 1
 return
 
 on_optin:
+int 0
+byte "counter"
+int 0
+app_local_put
 int 1
 return

--- a/packages/runtime/test/integration/close-clear-ssc.ts
+++ b/packages/runtime/test/integration/close-clear-ssc.ts
@@ -94,6 +94,7 @@ describe("ASC - CloseOut from Application and Clear State", function () {
     const appId = runtime.addApp(flags, {}, approvalProgram, clearProgram);
     closeOutParams.appId = appId;
     runtime.optInToApp(john.address, appId, {}, {}); // opt-in to app (set new local state)
+    syncAccount();
 
     // sending txn sender other than creator (john), so txn should be rejected
     closeOutParams.fromAccount = alice.account;

--- a/packages/runtime/test/integration/stateful-counter.ts
+++ b/packages/runtime/test/integration/stateful-counter.ts
@@ -1,7 +1,7 @@
 import { assert } from "chai";
 
 import { Runtime, StoreAccount } from "../../src/index";
-import { BIGINT1 } from "../../src/interpreter/opcode-list";
+import { BIGINT0, BIGINT1 } from "../../src/interpreter/opcode-list";
 import { ALGORAND_ACCOUNT_MIN_BALANCE } from "../../src/lib/constants";
 import { ExecParams, SignType, TransactionType } from "../../src/types";
 import { getProgram } from "../helpers/files";
@@ -41,6 +41,13 @@ describe("Algorand Smart Contracts - Stateful Counter example", function () {
   });
 
   const key = "counter";
+
+  it("should initialize local counter to 0 after opt-in", function () {
+    const localCounter = runtime.getAccount(john.address).getLocalState(txnParams.appId, key); // get local value from john account
+    assert.isDefined(localCounter); // there should be a value present in local state with key "counter"
+    assert.equal(localCounter, BIGINT0);
+  });
+
   it("should initialize global and local counter to 1 on first call", function () {
     runtime.executeTx(txnParams);
 


### PR DESCRIPTION
If I don't change the order of method execution in the `optInToApp` in the `runtime.ts` then I get the following errors when running the test:

```
1) ASC - CloseOut from Application and Clear State
       should successfully closeOut from app and update state according to asc:
     Error: TEAL_ERR24: Application Index 1 not found or is invalid at line unknown
      at StoreAccount.closeApp (src/account.ts:208:13)
      at /Users/sebastiangula/algorand-builder/packages/runtime/src/runtime.ts:502:25
      at Array.forEach (<anonymous>)
      at Runtime.updateFinalState (src/runtime.ts:483:15)
      at Runtime.executeTx (src/runtime.ts:581:10)
      at Context.<anonymous> (test/integration/close-clear-ssc.ts:58:13)
      at processImmediate (node:internal/timers:463:21)

  2) ASC - CloseOut from Application and Clear State
       should not delete application on CloseOut call if logic is rejected:
     AssertionError: expected undefined to not equal undefined
      at Context.<anonymous> (test/integration/close-clear-ssc.ts:106:12)
      at processImmediate (node:internal/timers:463:21)

  3) ASC - CloseOut from Application and Clear State
       should delete application on clearState call even if logic is rejected:
     AssertionError: expected undefined to not equal undefined
      at Context.<anonymous> (test/integration/close-clear-ssc.ts:126:12)
      at processImmediate (node:internal/timers:463:21)

  4) Algorand Smart Contracts - Stateful Counter example
       "before all" hook for "should initialize local counter to 0 after opt-in":
     Error: TEAL_ERR24: Application Index 1 not found or is invalid at line 57
      at StoreAccount.setLocalState (src/account.ts:92:11)
      at AppLocalPut.execute (src/interpreter/opcode-list.ts:1743:32)
      at Interpreter.execute (src/interpreter/interpreter.ts:158:19)
      at Runtime.run (src/runtime.ts:592:17)
      at Runtime.optInToApp (src/runtime.ts:341:12)
      at Context.<anonymous> (test/integration/stateful-counter.ts:39:13)
      at processImmediate (node:internal/timers:463:21)
```
I'm not sure if this is the correct way to fix this issue as I'm still learning about the inner workings of Algorand.