### PR TITLE
[Fix] Txn related ops

### DIFF
--- a/examples/restricted-assets/assets/poi-approval.teal
+++ b/examples/restricted-assets/assets/poi-approval.teal
@@ -1,5 +1,5 @@
-// source: https://github.com/algorand/smart-contracts/blob/master/devrel/poi/poi.teal
 #pragma version 2
+// source: https://github.com/algorand/smart-contracts/blob/master/devrel/poi/poi.teal
 // Creator Address
 // check if the app is being created
 // if so save creator

--- a/examples/restricted-assets/assets/poi-approval.teal
+++ b/examples/restricted-assets/assets/poi-approval.teal
@@ -302,8 +302,12 @@ return
 // By default, disallow updating or deleting the app. Add custom authorization
 // logic below to allow updating or deletion in certain circumstances.
 handle_updateapp:
-handle_deleteapp:
 err
+// update below code to throw err to block delete call
+handle_deleteapp:
+int 1
+return
+
 failed:
 int 0
 return

--- a/examples/restricted-assets/assets/poi-clear.teal
+++ b/examples/restricted-assets/assets/poi-clear.teal
@@ -1,4 +1,4 @@
-// source: https://github.com/algorand/smart-contracts/blob/master/devrel/poi/poi-clear.teal
 #pragma version 2
+// source: https://github.com/algorand/smart-contracts/blob/master/devrel/poi/poi-clear.teal
 int 1
 return

--- a/examples/restricted-assets/scripts/0-createAppAsset.js
+++ b/examples/restricted-assets/scripts/0-createAppAsset.js
@@ -8,7 +8,7 @@ async function run (runtimeEnv, deployer) {
   const creator = deployer.accountsByName.get('alice');
   const bob = deployer.accountsByName.get('bob');
 
-  /** Fund Creator account by master **/
+  /** Fund Creator & Bob account by master **/
   const algoTxnParams = {
     type: types.TransactionType.TransferAlgo,
     sign: types.SignType.SecretKey,
@@ -17,6 +17,8 @@ async function run (runtimeEnv, deployer) {
     amountMicroAlgos: 200e6,
     payFlags: {}
   };
+  await executeTransaction(deployer, algoTxnParams);
+  algoTxnParams.toAccountAddr = bob.addr;
   await executeTransaction(deployer, algoTxnParams);
 
   const asaInfo = await deployer.deployASA('gold', { creator: creator });

--- a/packages/runtime/src/errors/errors-list.ts
+++ b/packages/runtime/src/errors/errors-list.ts
@@ -38,7 +38,7 @@ permissible range of 1 to 256`
   },
   INVALID_OP_ARG: {
     number: 1002,
-    message: "Error encountered while executing teal with opcode %opcode% , Line : %line% ",
+    message: "Error encountered while executing teal with opcode %opcode% for teal version #%version% at line %line%",
     title: "Invalid Operation",
     description: `Error encountered in stack while executing teal opcode %opcode%`
   },

--- a/packages/runtime/src/interpreter/opcode-list.ts
+++ b/packages/runtime/src/interpreter/opcode-list.ts
@@ -1178,6 +1178,7 @@ export class Substring3 extends Op {
 // push to stack [...stack, transaction field]
 export class Txn extends Op {
   readonly field: string;
+  readonly idx: number | undefined;
   readonly interpreter: Interpreter;
   readonly line: number;
 
@@ -1192,7 +1193,14 @@ export class Txn extends Op {
   constructor (args: string[], line: number, interpreter: Interpreter) {
     super();
     this.line = line;
-    assertLen(args.length, 1, line);
+    this.idx = undefined;
+    if (args[0] === "ApplicationArgs" || args[0] === "Accounts") { // eg. txn Accounts 1
+      assertLen(args.length, 2, line);
+      assertOnlyDigits(args[1], line);
+      this.idx = Number(args[1]);
+    } else {
+      assertLen(args.length, 1, line);
+    }
     this.assertTxFieldDefined(args[0], interpreter.tealVersion, line);
 
     this.field = args[0]; // field
@@ -1200,11 +1208,17 @@ export class Txn extends Op {
   }
 
   execute (stack: TEALStack): void {
-    const result = txnSpecbyField(
-      this.field,
-      this.interpreter.runtime.ctx.tx,
-      this.interpreter.runtime.ctx.gtxs,
-      this.interpreter.tealVersion);
+    let result;
+    if (this.idx !== undefined) { // if field is an array use txAppArg (with "Accounts"/"ApplicationArgs")
+      result = txAppArg(this.field, this.interpreter.runtime.ctx.tx, this.idx, this,
+        this.interpreter.tealVersion, this.line);
+    } else {
+      result = txnSpecbyField(
+        this.field,
+        this.interpreter.runtime.ctx.tx,
+        this.interpreter.runtime.ctx.gtxs,
+        this.interpreter.tealVersion);
+    }
     stack.push(result);
   }
 }
@@ -1215,12 +1229,13 @@ export class Txn extends Op {
 export class Gtxn extends Op {
   readonly field: string;
   readonly txIdx: number;
+  readonly txFieldIdx: number | undefined;
   readonly interpreter: Interpreter;
   readonly line: number;
 
   /**
    * Sets `field`, `txIdx` values according to arguments passed.
-   * @param args Expected argumensts: [transaction group index, transaction field]
+   * @param args Expected arguments: [transaction group index, transaction field]
    * // Note: Transaction field is expected as string instead of number.
    * For ex: `Fee` is expected and `0` is not expected.
    * @param line line number in TEAL file
@@ -1229,7 +1244,14 @@ export class Gtxn extends Op {
   constructor (args: string[], line: number, interpreter: Interpreter) {
     super();
     this.line = line;
-    assertLen(args.length, 2, line);
+    this.txFieldIdx = undefined;
+    if (args[1] === "ApplicationArgs" || args[1] === "Accounts") {
+      assertLen(args.length, 3, line); // eg. gtxn 0 Accounts 1
+      assertOnlyDigits(args[2], line);
+      this.txFieldIdx = Number(args[2]);
+    } else {
+      assertLen(args.length, 2, line);
+    }
     assertOnlyDigits(args[0], line);
     this.assertTxFieldDefined(args[1], interpreter.tealVersion, line);
 
@@ -1241,12 +1263,18 @@ export class Gtxn extends Op {
   execute (stack: TEALStack): void {
     this.assertUint8(BigInt(this.txIdx), this.line);
     this.checkIndexBound(this.txIdx, this.interpreter.runtime.ctx.gtxs, this.line);
+    let result;
 
-    const result = txnSpecbyField(
-      this.field,
-      this.interpreter.runtime.ctx.gtxs[this.txIdx],
-      this.interpreter.runtime.ctx.gtxs,
-      this.interpreter.tealVersion);
+    if (this.txFieldIdx !== undefined) {
+      const tx = this.interpreter.runtime.ctx.gtxs[this.txIdx]; // current tx
+      result = txAppArg(this.field, tx, this.txFieldIdx, this, this.interpreter.tealVersion, this.line);
+    } else {
+      result = txnSpecbyField(
+        this.field,
+        this.interpreter.runtime.ctx.gtxs[this.txIdx],
+        this.interpreter.runtime.ctx.gtxs,
+        this.interpreter.tealVersion);
+    }
     stack.push(result);
   }
 }
@@ -1274,7 +1302,7 @@ export class Txna extends Op {
     this.line = line;
     assertLen(args.length, 2, line);
     assertOnlyDigits(args[1], line);
-    this.assertTxFieldDefined(args[0], interpreter.tealVersion, line);
+    this.assertTxArrFieldDefined(args[0], interpreter.tealVersion, line);
 
     this.field = args[0]; // field
     this.idx = Number(args[1]);
@@ -1314,7 +1342,7 @@ export class Gtxna extends Op {
     assertLen(args.length, 3, line);
     assertOnlyDigits(args[0], line);
     assertOnlyDigits(args[2], line);
-    this.assertTxFieldDefined(args[1], interpreter.tealVersion, line);
+    this.assertTxArrFieldDefined(args[1], interpreter.tealVersion, line);
 
     this.txIdx = Number(args[0]); // transaction group index
     this.field = args[1]; // field

--- a/packages/runtime/src/interpreter/opcode-list.ts
+++ b/packages/runtime/src/interpreter/opcode-list.ts
@@ -1279,10 +1279,13 @@ export class Gtxn extends Op {
   }
 }
 
-// push value of an array field from current transaction to stack
-// push to stack [...stack, value of an array field ]
-// NOTE: for arg="Accounts" index 0 means sender's address, and index 1 means first address
-// from accounts array (eg. txna Accounts 1: will push 1st address from Accounts[] to stack)
+/**
+ * push value of an array field from current transaction to stack
+ * push to stack [...stack, value of an array field ]
+ * NOTE: a) for arg="Accounts" index 0 means sender's address, and index 1 means first address
+ * from accounts array (eg. txna Accounts 1: will push 1st address from Accounts[] to stack)
+ * b) for arg="ApplicationArgs" index 0 means first argument for application array (normal indexing)
+ */
 export class Txna extends Op {
   readonly field: string;
   readonly idx: number;
@@ -1316,10 +1319,13 @@ export class Txna extends Op {
   }
 }
 
-// push value of a field to the stack from a transaction in the current transaction group
-// push to stack [...stack, value of field]
-// NOTE: for arg="Accounts" index 0 means sender's address, and index 1 means first address from accounts
-// array (eg. gtxna 0 Accounts 1: will push 1st address from Accounts[](from the 1st tx in group) to stack)
+/**
+ * push value of a field to the stack from a transaction in the current transaction group
+ * push to stack [...stack, value of field]
+ * NOTE: for arg="Accounts" index 0 means sender's address, and index 1 means first address from accounts
+ * array (eg. gtxna 0 Accounts 1: will push 1st address from Accounts[](from the 1st tx in group) to stack)
+ * b) for arg="ApplicationArgs" index 0 means first argument for application array (normal indexing)
+ */
 export class Gtxna extends Op {
   readonly field: string;
   readonly txIdx: number; // transaction group index

--- a/packages/runtime/src/interpreter/opcode-list.ts
+++ b/packages/runtime/src/interpreter/opcode-list.ts
@@ -1253,6 +1253,8 @@ export class Gtxn extends Op {
 
 // push value of an array field from current transaction to stack
 // push to stack [...stack, value of an array field ]
+// NOTE: for arg="Accounts" index 0 means sender's address, and index 1 means first address
+// from accounts array (eg. txna Accounts 1: will push 1st address from Accounts[] to stack)
 export class Txna extends Op {
   readonly field: string;
   readonly idx: number;
@@ -1288,6 +1290,8 @@ export class Txna extends Op {
 
 // push value of a field to the stack from a transaction in the current transaction group
 // push to stack [...stack, value of field]
+// NOTE: for arg="Accounts" index 0 means sender's address, and index 1 means first address from accounts
+// array (eg. gtxna 0 Accounts 1: will push 1st address from Accounts[](from the 1st tx in group) to stack)
 export class Gtxna extends Op {
   readonly field: string;
   readonly txIdx: number; // transaction group index

--- a/packages/runtime/src/interpreter/opcode.ts
+++ b/packages/runtime/src/interpreter/opcode.ts
@@ -139,6 +139,19 @@ export class Op {
   }
 
   /**
+   * asserts if known transaction field of type array is passed
+   * @param str transaction field
+   * @param tealVersion version of TEAL
+   * @param line line number in TEAL file
+   */
+  assertTxArrFieldDefined (str: string, tealVersion: number, line: number): void {
+    if (!(tealVersion >= 2 && (str === 'Accounts' || str === 'ApplicationArgs'))) {
+      throw new RuntimeError(RUNTIME_ERRORS.TEAL.INVALID_OP_ARG,
+        { opcode: "txna or gtxna", version: tealVersion, line: line });
+    }
+  }
+
+  /**
    * asserts if known global field is passed
    * @param str global field
    * @param tealVersion version of TEAL

--- a/packages/runtime/src/lib/txn.ts
+++ b/packages/runtime/src/lib/txn.ts
@@ -104,11 +104,6 @@ export function txnSpecbyField (txField: string, tx: Txn, gtxns: Txn[], tealVers
  */
 export function txAppArg (txField: TxField, tx: Txn, idx: number, op: Op,
   tealVersion: number, line: number): Uint8Array {
-  if (txField !== 'Accounts' && txField !== 'ApplicationArgs') {
-    throw new RuntimeError(RUNTIME_ERRORS.TEAL.INVALID_OP_ARG, {
-      opcode: "txna or gtxna"
-    });
-  }
   const s = TxnFields[tealVersion][txField]; // 'apaa' or 'apat'
   const result = tx[s as keyof Txn] as Buffer[]; // array of pk buffers (accounts or appArgs)
   if (!result) { // handle defaults

--- a/packages/runtime/src/lib/txn.ts
+++ b/packages/runtime/src/lib/txn.ts
@@ -104,20 +104,23 @@ export function txnSpecbyField (txField: string, tx: Txn, gtxns: Txn[], tealVers
  */
 export function txAppArg (txField: TxField, tx: Txn, idx: number, op: Op,
   tealVersion: number, line: number): Uint8Array {
-  if (txField === 'Accounts' || txField === 'ApplicationArgs') {
-    const s = TxnFields[tealVersion][txField]; // 'apaa' or 'apat'
-    const result = tx[s as keyof Txn] as Buffer[]; // array of pk buffers (accounts or appArgs)
-
-    if (!result) { // handle
-      return TxFieldDefaults[txField];
-    }
-    op.checkIndexBound(idx, result, line);
-    return parseToStackElem(result[idx], txField) as Uint8Array;
+  if (txField !== 'Accounts' && txField !== 'ApplicationArgs') {
+    throw new RuntimeError(RUNTIME_ERRORS.TEAL.INVALID_OP_ARG, {
+      opcode: "txna or gtxna"
+    });
+  }
+  const s = TxnFields[tealVersion][txField]; // 'apaa' or 'apat'
+  const result = tx[s as keyof Txn] as Buffer[]; // array of pk buffers (accounts or appArgs)
+  if (!result) { // handle defaults
+    return TxFieldDefaults[txField];
   }
 
-  throw new RuntimeError(RUNTIME_ERRORS.TEAL.INVALID_OP_ARG, {
-    opcode: "txna or gtxna"
-  });
+  if (txField === 'Accounts') {
+    if (idx === 0) { return parseToStackElem(tx.snd, txField) as Uint8Array; }
+    idx--; // if not sender, then reduce index by 1
+  }
+  op.checkIndexBound(idx, result, line);
+  return parseToStackElem(result[idx], txField) as Uint8Array;
 }
 
 export function encodeNote (note: string | undefined, noteb64: string| undefined): Uint8Array | undefined {

--- a/packages/runtime/test/src/interpreter/opcode-list.ts
+++ b/packages/runtime/test/src/interpreter/opcode-list.ts
@@ -1974,8 +1974,24 @@ describe("Teal Opcodes", function () {
         interpreter.runtime.ctx.tx.type = 'pay';
       });
 
-      it("push addr from 2nd account to stack", function () {
-        const op = new Txna(["Accounts", "1"], 1, interpreter);
+      it("push addr from txn.Accounts to stack according to index", function () {
+        // index 0 should push sender's address to stack
+        let op = new Txna(["Accounts", "0"], 1, interpreter);
+        op.execute(stack);
+
+        const senderPk = Uint8Array.from(interpreter.runtime.ctx.tx.snd);
+        assert.equal(1, stack.length());
+        assert.deepEqual(senderPk, stack.pop());
+
+        // should push Accounts[0] to stack
+        op = new Txna(["Accounts", "1"], 1, interpreter);
+        op.execute(stack);
+
+        assert.equal(1, stack.length());
+        assert.deepEqual(TXN_OBJ.apat[0], stack.pop());
+
+        // should push Accounts[1] to stack
+        op = new Txna(["Accounts", "2"], 1, interpreter);
         op.execute(stack);
 
         assert.equal(1, stack.length());
@@ -1997,7 +2013,23 @@ describe("Teal Opcodes", function () {
       });
 
       it("push addr from 1st account of 2nd Txn in txGrp to stack", function () {
-        const op = new Gtxna(["0", "Accounts", "1"], 1, interpreter);
+        // index 0 should push sender's address to stack from 1st tx
+        let op = new Gtxna(["0", "Accounts", "1"], 1, interpreter);
+        op.execute(stack);
+
+        const senderPk = Uint8Array.from(interpreter.runtime.ctx.gtxs[0].snd);
+        assert.equal(1, stack.length());
+        assert.deepEqual(senderPk, stack.pop());
+
+        // should push Accounts[0] to stack
+        op = new Gtxna(["0", "Accounts", "1"], 1, interpreter);
+        op.execute(stack);
+
+        assert.equal(1, stack.length());
+        assert.deepEqual(TXN_OBJ.apat[0], stack.pop());
+
+        // should push Accounts[1] to stack
+        op = new Gtxna(["0", "Accounts", "2"], 1, interpreter);
         op.execute(stack);
 
         assert.equal(1, stack.length());

--- a/packages/runtime/test/src/interpreter/opcode-list.ts
+++ b/packages/runtime/test/src/interpreter/opcode-list.ts
@@ -1951,6 +1951,35 @@ describe("Teal Opcodes", function () {
         assert.equal(1, stack.length());
         assert.deepEqual(TXN_OBJ.apsu, stack.pop());
       });
+
+      it("should push value from accounts or args array by index", function () {
+        let op = new Txn(["Accounts", "0"], 1, interpreter);
+        op.execute(stack);
+
+        const senderPk = Uint8Array.from(interpreter.runtime.ctx.tx.snd);
+        assert.equal(1, stack.length());
+        assert.deepEqual(senderPk, stack.pop());
+
+        // should push Accounts[0] to stack
+        op = new Txn(["Accounts", "1"], 1, interpreter);
+        op.execute(stack);
+
+        assert.equal(1, stack.length());
+        assert.deepEqual(TXN_OBJ.apat[0], stack.pop());
+
+        // should push Accounts[1] to stack
+        op = new Txn(["Accounts", "2"], 1, interpreter);
+        op.execute(stack);
+
+        assert.equal(1, stack.length());
+        assert.deepEqual(TXN_OBJ.apat[1], stack.pop());
+
+        op = new Txn(["ApplicationArgs", "0"], 0, interpreter);
+        op.execute(stack);
+
+        assert.equal(1, stack.length());
+        assert.deepEqual(TXN_OBJ.apaa[0], stack.pop());
+      });
     });
 
     describe("Gtxn", function () {
@@ -1966,6 +1995,35 @@ describe("Teal Opcodes", function () {
 
         assert.equal(1, stack.length());
         assert.equal(BigInt('2222'), stack.pop());
+      });
+
+      it("should push value from accounts or args array by index from tx group", function () {
+        let op = new Gtxn(["1", "Accounts", "0"], 1, interpreter);
+        op.execute(stack);
+
+        const senderPk = Uint8Array.from(interpreter.runtime.ctx.tx.snd);
+        assert.equal(1, stack.length());
+        assert.deepEqual(senderPk, stack.pop());
+
+        // should push Accounts[0] to stack
+        op = new Gtxn(["1", "Accounts", "1"], 1, interpreter);
+        op.execute(stack);
+
+        assert.equal(1, stack.length());
+        assert.deepEqual(TXN_OBJ.apat[0], stack.pop());
+
+        // should push Accounts[1] to stack
+        op = new Gtxn(["1", "Accounts", "2"], 1, interpreter);
+        op.execute(stack);
+
+        assert.equal(1, stack.length());
+        assert.deepEqual(TXN_OBJ.apat[1], stack.pop());
+
+        op = new Gtxn(["1", "ApplicationArgs", "0"], 0, interpreter);
+        op.execute(stack);
+
+        assert.equal(1, stack.length());
+        assert.deepEqual(TXN_OBJ.apaa[0], stack.pop());
       });
     });
 

--- a/packages/runtime/test/src/parser/parser.ts
+++ b/packages/runtime/test/src/parser/parser.ts
@@ -394,9 +394,12 @@ describe("Parser", function () {
     });
 
     it("should return correct objects for `txn`", () => {
-      const res = opcodeFromSentence(["txn", "Fee"], 1, interpreter);
-      const expected = new Txn(["Fee"], 1, interpreter);
+      let res = opcodeFromSentence(["txn", "Fee"], 1, interpreter);
+      let expected = new Txn(["Fee"], 1, interpreter);
+      assert.deepEqual(res, expected);
 
+      res = opcodeFromSentence(["txn", "Accounts", "1"], 1, interpreter);
+      expected = new Txn(["Accounts", "1"], 1, interpreter);
       assert.deepEqual(res, expected);
 
       expectRuntimeError(
@@ -411,9 +414,12 @@ describe("Parser", function () {
     });
 
     it("should return correct object for `gtxn`", () => {
-      const res = opcodeFromSentence(["gtxn", "0", "Fee"], 1, interpreter);
-      const expected = new Gtxn(["0", "Fee"], 1, interpreter);
+      let res = opcodeFromSentence(["gtxn", "0", "Fee"], 1, interpreter);
+      let expected = new Gtxn(["0", "Fee"], 1, interpreter);
+      assert.deepEqual(res, expected);
 
+      res = opcodeFromSentence(["gtxn", "0", "ApplicationArgs", "0"], 1, interpreter);
+      expected = new Gtxn(["0", "ApplicationArgs", "0"], 1, interpreter);
       assert.deepEqual(res, expected);
 
       expectRuntimeError(
@@ -428,10 +434,18 @@ describe("Parser", function () {
     });
 
     it("should return correct object for `txna`", () => {
-      const res = opcodeFromSentence(["txna", "Fee", "2"], 1, interpreter);
-      const expected = new Txna(["Fee", "2"], 1, interpreter);
-
+      let res = opcodeFromSentence(["txna", "Accounts", "0"], 1, interpreter);
+      let expected = new Txna(["Accounts", "0"], 1, interpreter);
       assert.deepEqual(res, expected);
+
+      res = opcodeFromSentence(["txna", "ApplicationArgs", "2"], 1, interpreter);
+      expected = new Txna(["ApplicationArgs", "2"], 1, interpreter);
+      assert.deepEqual(res, expected);
+
+      expectRuntimeError(
+        () => opcodeFromSentence(["txna", "Fee", "2"], 1, interpreter),
+        RUNTIME_ERRORS.TEAL.INVALID_OP_ARG
+      );
 
       expectRuntimeError(
         () => opcodeFromSentence(["txna", "2"], 1, interpreter),
@@ -445,10 +459,18 @@ describe("Parser", function () {
     });
 
     it("should return correct object for `gtxna`", () => {
-      const res = opcodeFromSentence(["gtxna", "1", "Fee", "4"], 1, interpreter);
-      const expected = new Gtxna(["1", "Fee", "4"], 1, interpreter);
-
+      let res = opcodeFromSentence(["gtxna", "1", "Accounts", "1"], 1, interpreter);
+      let expected = new Gtxna(["1", "Accounts", "1"], 1, interpreter);
       assert.deepEqual(res, expected);
+
+      res = opcodeFromSentence(["gtxna", "1", "ApplicationArgs", "4"], 1, interpreter);
+      expected = new Gtxna(["1", "ApplicationArgs", "4"], 1, interpreter);
+      assert.deepEqual(res, expected);
+
+      expectRuntimeError(
+        () => opcodeFromSentence(["gtxna", "1", "Fee", "4"], 1, interpreter),
+        RUNTIME_ERRORS.TEAL.INVALID_OP_ARG
+      );
 
       expectRuntimeError(
         () => opcodeFromSentence(["gtxna", "1", "2", "3", "4"], 1, interpreter),

--- a/packages/runtime/test/src/parser/parser.ts
+++ b/packages/runtime/test/src/parser/parser.ts
@@ -402,6 +402,10 @@ describe("Parser", function () {
       expected = new Txn(["Accounts", "1"], 1, interpreter);
       assert.deepEqual(res, expected);
 
+      res = opcodeFromSentence(["txn", "ApplicationArgs", "0"], 1, interpreter);
+      expected = new Txn(["ApplicationArgs", "0"], 1, interpreter);
+      assert.deepEqual(res, expected);
+
       expectRuntimeError(
         () => opcodeFromSentence(["txn", "Fee", "Fee"], 1, interpreter),
         RUNTIME_ERRORS.TEAL.ASSERT_LENGTH


### PR DESCRIPTION
- Support for array arguments for `txn`, `gtxn` (eg. `txn Accounts 0`, `gtxn 0 Accounts 0`)
- Fix indexing with `txna`, `gtxna` (0 index meaning the sender's address)
- Fix tests in Parser + add more tests

Closes #245 as well.